### PR TITLE
In the case we are always sending metrics, there is no need to call the ...

### DIFF
--- a/src/StatsdClient/RandomGenerator.cs
+++ b/src/StatsdClient/RandomGenerator.cs
@@ -12,6 +12,7 @@ namespace StatsdClient
 
         public bool ShouldSend(double sampleRate)
         {
+            if (sampleRate >= 1) return true;
             return _random.NextDouble() < sampleRate;
         }
     }


### PR DESCRIPTION
...RNG to check against the sample rate. I'm not sure if this is a huge performance benefit, but seems like it could help in high usage scenarios.
