### PR TITLE
Added ability to specify global tags as part of configuration

### DIFF
--- a/src/StatsdClient/Metrics.cs
+++ b/src/StatsdClient/Metrics.cs
@@ -6,6 +6,7 @@ namespace StatsdClient
     {
         private static Statsd _statsD;
         private static string _prefix;
+        private static string[] _tags;
 
         public static void Configure(MetricsConfig config)
         {
@@ -16,6 +17,7 @@ namespace StatsdClient
                 throw new ArgumentNullException("config.StatsdServername");
 
             _prefix = config.Prefix;
+            _tags = config.Tags;
             _statsD = string.IsNullOrEmpty(config.StatsdServerName)
                       ? null
                       : new Statsd(new StatsdUDP(config.StatsdServerName, config.StatsdPort, config.StatsdMaxUDPPacketSize));
@@ -27,7 +29,7 @@ namespace StatsdClient
             {
                 return;
             }
-            _statsD.Send<Statsd.Counting,T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
+            _statsD.Send<Statsd.Counting,T>(BuildNamespacedStatName(statName), value, sampleRate, MergeTags(tags));
         }
 
         public static void Increment(string statName, double sampleRate = 1.0, string[] tags = null)  
@@ -36,7 +38,7 @@ namespace StatsdClient
             {
                 return;
             }
-            _statsD.Send<Statsd.Counting,int>(BuildNamespacedStatName(statName), 1, sampleRate, tags);
+            _statsD.Send<Statsd.Counting, int>(BuildNamespacedStatName(statName), 1, sampleRate, MergeTags(tags));
         }
 
         public static void Decrement(string statName, double sampleRate = 1.0, params string[] tags)  
@@ -45,7 +47,7 @@ namespace StatsdClient
             {
                 return;
             }
-            _statsD.Send<Statsd.Counting,int>(BuildNamespacedStatName(statName), -1, sampleRate, tags);
+            _statsD.Send<Statsd.Counting, int>(BuildNamespacedStatName(statName), -1, sampleRate, MergeTags(tags));
         }
 
         public static void Gauge<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
@@ -54,7 +56,7 @@ namespace StatsdClient
             {
                 return;
             }
-            _statsD.Send<Statsd.Gauge,T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
+            _statsD.Send<Statsd.Gauge, T>(BuildNamespacedStatName(statName), value, sampleRate, MergeTags(tags));
         }
 
         public static void Histogram<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
@@ -63,7 +65,7 @@ namespace StatsdClient
             {
                 return;
             }
-            _statsD.Send<Statsd.Histogram,T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
+            _statsD.Send<Statsd.Histogram, T>(BuildNamespacedStatName(statName), value, sampleRate, MergeTags(tags));
         }
 
         public static void Set<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
@@ -72,7 +74,7 @@ namespace StatsdClient
             {
                 return;
             }
-            _statsD.Send<Statsd.Set,T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
+            _statsD.Send<Statsd.Set, T>(BuildNamespacedStatName(statName), value, sampleRate, MergeTags(tags));
         }
 
         public static void Timer<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
@@ -82,13 +84,13 @@ namespace StatsdClient
                 return;
             }
 
-            _statsD.Send<Statsd.Timing,T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
+            _statsD.Send<Statsd.Timing, T>(BuildNamespacedStatName(statName), value, sampleRate, MergeTags(tags));
         }
 
 
         public static IDisposable StartTimer(string name, double sampleRate = 1.0, string[] tags = null)
         {
-            return new MetricsTimer(name, sampleRate, tags);
+            return new MetricsTimer(name, sampleRate, MergeTags(tags));
         }
 
         public static void Time(Action action, string statName, double sampleRate = 1.0, string[] tags = null) 
@@ -99,7 +101,7 @@ namespace StatsdClient
             }
             else
             {
-                _statsD.Send(action, BuildNamespacedStatName(statName), sampleRate, tags);
+                _statsD.Send(action, BuildNamespacedStatName(statName), sampleRate, MergeTags(tags));
             }
         }
 
@@ -110,7 +112,7 @@ namespace StatsdClient
                 return func();
             }
 
-            using (StartTimer(statName, sampleRate, tags))
+            using (StartTimer(statName, sampleRate, MergeTags(tags)))
             {
                 return func();
             }
@@ -124,6 +126,31 @@ namespace StatsdClient
             }
 
             return _prefix + "." + statName;
+        }
+
+        private static string[] MergeTags(string[] tags)
+        {
+            if (tags == null && _tags == null)
+            {
+                return null;
+            }
+            else if (tags == null && _tags != null)
+            {
+                return _tags;
+            }
+            else if (tags != null && _tags == null)
+            {
+                return tags;
+            }
+            else
+            {
+                string[] mergedTags = new string[tags.Length + _tags.Length];
+                _tags.CopyTo(mergedTags, 0);
+                tags.CopyTo(mergedTags, _tags.Length);
+
+                return mergedTags;
+            }
+                
         }
     }
 }

--- a/src/StatsdClient/MetricsConfig.cs
+++ b/src/StatsdClient/MetricsConfig.cs
@@ -6,6 +6,7 @@
         public int StatsdPort { get; set; }
         public int StatsdMaxUDPPacketSize { get; set; }
 		public string Prefix { get; set; }
+        public string[] Tags { get; set; }
 
         public const int DefaultStatsdPort = 8125;
         public const int DefaultStatsdMaxUDPPacketSize = 512;


### PR DESCRIPTION
In our environment we only want to run a single instance of the DogStatsD agent.  We then need to configure each server to tag their stats as being related to a particular host so that we can filter and graph across hosts.  This pull request allows you to set a tag at config time that will be applied to all stats.  We are adding a tag called hosts with a value of Naming.CurrentHostName so that all stats are tagged with this.
