### PR TITLE
Do not sign assemblies at build by default

### DIFF
--- a/src/Configuration/StatsdClient.Configuration.csproj
+++ b/src/Configuration/StatsdClient.Configuration.csproj
@@ -31,12 +31,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>dogstatsd-csharp-client.pfx</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -46,11 +40,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Naming.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="dogstatsd-csharp-client.pfx" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/StatsdClient/StatsdClient.csproj
+++ b/src/StatsdClient/StatsdClient.csproj
@@ -31,12 +31,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>dogstatsd-csharp-client.pfx</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -64,11 +58,8 @@
       <Name>StatsdClient.Configuration</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="dogstatsd-csharp-client.pfx" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>


### PR DESCRIPTION
Prevent users from having to uncheck "Sign in" option in VS to avoid signing assemblies at build (which requires a password). 