### PR TITLE
Strip Windows carriage returns "\r" in EscapeContent()

### DIFF
--- a/src/StatsdClient/Statsd.cs
+++ b/src/StatsdClient/Statsd.cs
@@ -95,7 +95,9 @@ namespace StatsdClient
 
             private static string EscapeContent(string content)
             {
-                return content.Replace("\n", "\\n");
+                return content
+                    .Replace("\r", "")
+                    .Replace("\n", "\\n");
             }
         }
 

--- a/src/Tests/MetricsAndEventsIntegrationTests.cs
+++ b/src/Tests/MetricsAndEventsIntegrationTests.cs
@@ -581,7 +581,7 @@ namespace Tests
         [Test]
         public void events_priority_and_date()
         {
-            DogStatsd.Event("Title", "L1\nL2", priority: "low", dateHappened: 1375296969);
+            DogStatsd.Event("Title", "L1\r\nL2", priority: "low", dateHappened: 1375296969);
             AssertWasReceived("_e{5,6}:Title|L1\\nL2|d:1375296969|p:low");
         }
 


### PR DESCRIPTION
When there are carriage returns `\r` in an event's text, the portion after the first `\r` does not make it into DataDog's event feed.

For example, an exception's stack trace contains `\r\n` at the end of every line. Stripping the character when escaping content seems like a reasonable thing to do.