### PR TITLE
DogStatsd threading patch

### DIFF
--- a/src/StatsdClient/Statsd.cs
+++ b/src/StatsdClient/Statsd.cs
@@ -150,21 +150,25 @@ namespace StatsdClient
 
         public void Send(string command)
         {
-            Commands = new List<string> { command };
-            Send();
-        }
-
-        public void Send()
-        {
             try
             {
-                Udp.Send(string.Join("\n", Commands.ToArray()));
-                Commands = new List<string>();
+                Udp.Send(command);
+                // clear buffer (keep existing behavior)
+                if (Commands.Count > 0)
+                    Commands = new List<string>();
             }
             catch (Exception e)
             {
                 Debug.WriteLine(e.Message);
             }
+        }
+
+        public void Send()
+        {
+            int count = Commands.Count;
+            if (count < 1) return;
+
+            Send(1 == count ? Commands[0] : string.Join("\n", Commands.ToArray()));
         }
 
         public void Add(Action actionToTime, string statName, double sampleRate = 1.0, string[] tags = null)

--- a/src/Tests/StatsdClient.Tests.csproj
+++ b/src/Tests/StatsdClient.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="IPV4ParsingTests.cs" />
     <Compile Include="NamingIntegrationTests.cs" />
     <Compile Include="RandomGeneratorUnitTests.cs" />
+    <Compile Include="StatsdThreadingTests.cs" />
     <Compile Include="UDPSmokeTests.cs" />
     <Compile Include="StatsdUnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Tests/StatsdThreadingTests.cs
+++ b/src/Tests/StatsdThreadingTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+using NUnit.Framework;
+
+using StatsdClient;
+
+namespace Tests
+{
+    [TestFixture]
+    public class StatsdThreadingTests
+    {
+        [Test]
+        public void single_send_is_thread_safe()
+        {
+            var counts = new CountingUDP();
+            var test = new Statsd(counts);
+
+            // send some commands in parallel, `command' just being a number in sequence
+            int sends = 1024, threads = 2; // appears sufficient to surface error most of the time but may vary by machine
+            var sent = new ManualResetEvent[threads];
+            for (int i = 0; i < threads; i++)
+            {
+                var done = sent[i] = new ManualResetEvent(false);
+                ThreadPool.QueueUserWorkItem(CreateSender(sends, threads, i, test, done));
+            }
+            // allow threads to complete, cleanup
+            WaitHandle.WaitAll(sent);
+            foreach (IDisposable d in sent)
+                d.Dispose();
+
+            counts.ExpectSequence(sends);
+        }
+
+        static WaitCallback CreateSender(int sends, int threads, int which, IStatsd statsd, ManualResetEvent done)
+        {
+            return x => {
+                for (int i = 0; i < sends; i++)
+                    if (which == (i % threads))
+                        statsd.Send(i.ToString());
+                done.Set();
+            };
+        }
+
+        class CountingUDP : IStatsdUDP
+        {
+            readonly IDictionary<string, int> _commands = new Dictionary<string, int>();
+
+            public void Send(string command)
+            {
+                lock (_commands)
+                {
+                    int count;
+                    if (_commands.TryGetValue(command, out count))
+                        count++;
+                    else
+                        count = 1;
+                    _commands[command] = count;
+                }
+            }
+
+            public void ExpectSequence(int n)
+            {
+                int empty, missing = 0, dupes = 0;
+                if (!_commands.TryGetValue("", out empty))
+                    empty = 0;
+
+                for (int i = 0; i < n; i++)
+                {
+                    int count;
+                    if (!_commands.TryGetValue(i.ToString(), out count))
+                    {
+                        missing++;
+                        Console.Error.WriteLine("Missing command {0}", i);
+                    }
+                    else if (count > 1)
+                    {
+                        dupes++;
+                        Console.Error.WriteLine("{0} duplicates of command {1}", count, i);
+                    }
+                }
+
+                if (empty > 0 || missing > 0 || dupes > 0)
+                    Assert.Fail("{0} empty command(s), {1} missing, {2} duplicate(s)", empty, missing, dupes);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi-

I think there's a bit of a threading issue if DogStatsd methods are called concurrently.

DogStatsd sends its commands (eventually) through the Send(string) method of a singleton Statsd instance.
Statsd.Send(string) sets its command buffer and calls to no-arg Send(), which resets the buffer on completion.
If Send(string) is called concurrently from multiple threads, this can lead to dropped, duplicate, or empty commands, depending on the order of execution.

This pull switches the calling order, so that Send() calls Send(string); single-command sends don't set the buffer at all (although they do clear it to keep compatibility with existing behavior).

Could you take a look?

Thanks,
  Yori