### PR TITLE
Optional automatic truncation of events that exceed the message length limit

### DIFF
--- a/src/StatsdClient/IStatsd.cs
+++ b/src/StatsdClient/IStatsd.cs
@@ -8,7 +8,7 @@ namespace StatsdClient
         List<string> Commands { get; }
         void Send<TCommandType, T>(string name, T value, double sampleRate, params string[] tags) where TCommandType : StatsdClient.Statsd.Metric;
         void Add<TCommandType, T>(string name, T value, double sampleRate, params string[] tags) where TCommandType : StatsdClient.Statsd.Metric;
-        void Send(string title, string text, string alertType, string aggregationKey, string sourceType, int? dateHappened, string priority, string hostname, string[] tags);
+        void Send(string title, string text, string alertType, string aggregationKey, string sourceType, int? dateHappened, string priority, string hostname, string[] tags, bool truncateIfTooLong = false);
         void Add(string title, string text, string alertType, string aggregationKey, string sourceType, int? dateHappened, string priority, string hostname, string[] tags);
         void Send(string command);
         void Send();


### PR DESCRIPTION
We'd like metrics not to crash the application if the message happens to stray too long, preferring quiet truncation rather than exception throwing.

I've made the default behaviour retain the exception throwing, for backwards compat, but you can opt into truncation with an optional argument.

This should fix #16 too.