### PR TITLE
Abstractions

### DIFF
--- a/src/StatsdClient/DogStatsdService.cs
+++ b/src/StatsdClient/DogStatsdService.cs
@@ -1,0 +1,149 @@
+using System;
+
+namespace StatsdClient
+{
+    public class DogStatsdService
+    {
+        private Statsd _statsD;
+        private string _prefix;
+
+        public void Configure(StatsdConfig config)
+        {
+            if (config == null)
+                throw new ArgumentNullException("config");
+
+            if (string.IsNullOrEmpty(config.StatsdServerName))
+                throw new ArgumentNullException("config.StatsdServername");
+
+            _prefix = config.Prefix;
+            _statsD = string.IsNullOrEmpty(config.StatsdServerName)
+                      ? null
+                      : new Statsd(new StatsdUDP(config.StatsdServerName, config.StatsdPort, config.StatsdMaxUDPPacketSize));
+        }
+
+        public void Event(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, string[] tags = null)
+        {
+            if (_statsD == null)
+            {
+                return;
+            }
+            _statsD.Send(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, tags);
+        }
+
+
+        public void Counter<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
+        {
+            if (_statsD == null)
+            {
+                return;
+            }
+            _statsD.Send<Statsd.Counting, T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
+        }
+
+        public void Increment(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null)
+        {
+            if (_statsD == null)
+            {
+                return;
+            }
+            _statsD.Send<Statsd.Counting, int>(BuildNamespacedStatName(statName), value, sampleRate, tags);
+        }
+
+        public void Decrement(string statName, int value = 1, double sampleRate = 1.0, params string[] tags)
+        {
+            if (_statsD == null)
+            {
+                return;
+            }
+            _statsD.Send<Statsd.Counting, int>(BuildNamespacedStatName(statName), -value, sampleRate, tags);
+        }
+
+        public void Gauge<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
+        {
+            if (_statsD == null)
+            {
+                return;
+            }
+            _statsD.Send<Statsd.Gauge, T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
+        }
+
+        public void Histogram<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
+        {
+            if (_statsD == null)
+            {
+                return;
+            }
+            _statsD.Send<Statsd.Histogram, T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
+        }
+
+        public void Set<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
+        {
+            if (_statsD == null)
+            {
+                return;
+            }
+            _statsD.Send<Statsd.Set, T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
+        }
+
+        public void Timer<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
+        {
+            if (_statsD == null)
+            {
+                return;
+            }
+
+            _statsD.Send<Statsd.Timing, T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
+        }
+
+
+        public IDisposable StartTimer(string name, double sampleRate = 1.0, string[] tags = null)
+        {
+            return new MetricsTimer(name, sampleRate, tags);
+        }
+
+        public void Time(Action action, string statName, double sampleRate = 1.0, string[] tags = null)
+        {
+            if (_statsD == null)
+            {
+                action();
+            }
+            else
+            {
+                _statsD.Send(action, BuildNamespacedStatName(statName), sampleRate, tags);
+            }
+        }
+
+        public T Time<T>(Func<T> func, string statName, double sampleRate = 1.0, string[] tags = null)
+        {
+            if (_statsD == null)
+            {
+                return func();
+            }
+
+            using (StartTimer(statName, sampleRate, tags))
+            {
+                return func();
+            }
+        }
+
+        public void ServiceCheck(string name, Status status, int? timestamp = null, string hostname = null, string[] tags = null, string message = null)
+        {
+            if (_statsD == null)
+            {
+                return;
+            }
+
+            _statsD.Send(name, (int)status, timestamp, hostname, tags, message);
+        }
+
+        private string BuildNamespacedStatName(string statName)
+        {
+            if (string.IsNullOrEmpty(_prefix))
+            {
+                return statName;
+            }
+
+            return _prefix + "." + statName;
+        }
+    }
+}

--- a/src/StatsdClient/Dogstatsd.cs
+++ b/src/StatsdClient/Dogstatsd.cs
@@ -12,146 +12,49 @@ namespace StatsdClient
 
     public static class DogStatsd
     {
-        private static Statsd _statsD;
-        private static string _prefix;
+        private static readonly DogStatsdService _dogStatsdService = new DogStatsdService();
+        
+        public static void Configure(StatsdConfig config) => _dogStatsdService.Configure(config);
 
-        public static void Configure(StatsdConfig config)
-        {
-            if (config == null)
-                throw new ArgumentNullException("config");
+        public static void Event(string title, string text, string alertType = null, string aggregationKey = null,
+            string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null,
+            string[] tags = null)
+            =>
+                _dogStatsdService.Event(title: title, text: text, alertType: alertType, aggregationKey: aggregationKey, sourceType: sourceType, dateHappened: dateHappened, priority: priority,
+                    hostname: hostname, tags: tags);
 
-            if (string.IsNullOrEmpty(config.StatsdServerName))
-                throw new ArgumentNullException("config.StatsdServername");
+        public static void Counter<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null) =>
+            _dogStatsdService.Counter<T>(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
 
-            _prefix = config.Prefix;
-            _statsD = string.IsNullOrEmpty(config.StatsdServerName)
-                      ? null
-                      : new Statsd(new StatsdUDP(config.StatsdServerName, config.StatsdPort, config.StatsdMaxUDPPacketSize));
-        }
+        public static void Increment(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null) =>
+            _dogStatsdService.Increment(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
 
-        public static void Event(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, string[] tags = null)
-        {
-            if (_statsD == null)
-            {
-                return;
-            }
-            _statsD.Send(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, tags);
-        }
+        public static void Decrement(string statName, int value = 1, double sampleRate = 1.0, params string[] tags) =>
+            _dogStatsdService.Decrement(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
 
+        public static void Gauge<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null) =>
+            _dogStatsdService.Gauge<T>(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
 
-        public static void Counter<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
-        {
-            if (_statsD == null)
-            {
-                return;
-            }
-            _statsD.Send<Statsd.Counting, T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
-        }
+        public static void Histogram<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null) =>
+            _dogStatsdService.Histogram<T>(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
 
-        public static void Increment(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null)
-        {
-            if (_statsD == null)
-            {
-                return;
-            }
-            _statsD.Send<Statsd.Counting, int>(BuildNamespacedStatName(statName), value, sampleRate, tags);
-        }
+        public static void Set<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null) =>
+            _dogStatsdService.Set<T>(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
 
-        public static void Decrement(string statName, int value = 1, double sampleRate = 1.0, params string[] tags)
-        {
-            if (_statsD == null)
-            {
-                return;
-            }
-            _statsD.Send<Statsd.Counting, int>(BuildNamespacedStatName(statName), -value, sampleRate, tags);
-        }
+        public static void Timer<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null) =>
+            _dogStatsdService.Timer<T>(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
 
-        public static void Gauge<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
-        {
-            if (_statsD == null)
-            {
-                return;
-            }
-            _statsD.Send<Statsd.Gauge, T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
-        }
+        public static IDisposable StartTimer(string name, double sampleRate = 1.0, string[] tags = null) =>
+            _dogStatsdService.StartTimer(name: name, sampleRate: sampleRate, tags: tags);
 
-        public static void Histogram<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
-        {
-            if (_statsD == null)
-            {
-                return;
-            }
-            _statsD.Send<Statsd.Histogram, T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
-        }
+        public static void Time(Action action, string statName, double sampleRate = 1.0, string[] tags = null) =>
+            _dogStatsdService.Time(action: action, statName: statName, sampleRate: sampleRate, tags: tags);
 
-        public static void Set<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
-        {
-            if (_statsD == null)
-            {
-                return;
-            }
-            _statsD.Send<Statsd.Set, T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
-        }
+        public static T Time<T>(Func<T> func, string statName, double sampleRate = 1.0, string[] tags = null) =>
+            _dogStatsdService.Time<T>(func: func, statName: statName, sampleRate: sampleRate, tags: tags);
 
-        public static void Timer<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
-        {
-            if (_statsD == null)
-            {
-                return;
-            }
-
-            _statsD.Send<Statsd.Timing, T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
-        }
-
-
-        public static IDisposable StartTimer(string name, double sampleRate = 1.0, string[] tags = null)
-        {
-            return new MetricsTimer(name, sampleRate, tags);
-        }
-
-        public static void Time(Action action, string statName, double sampleRate = 1.0, string[] tags = null)
-        {
-            if (_statsD == null)
-            {
-                action();
-            }
-            else
-            {
-                _statsD.Send(action, BuildNamespacedStatName(statName), sampleRate, tags);
-            }
-        }
-
-        public static T Time<T>(Func<T> func, string statName, double sampleRate = 1.0, string[] tags = null)
-        {
-            if (_statsD == null)
-            {
-                return func();
-            }
-
-            using (StartTimer(statName, sampleRate, tags))
-            {
-                return func();
-            }
-        }
-
-        public static void ServiceCheck(string name, Status status, int? timestamp = null, string hostname = null, string[] tags = null, string message = null)
-        {
-            if (_statsD == null)
-            {
-                return;
-            }
-
-            _statsD.Send(name, (int)status, timestamp, hostname, tags, message);
-        }
-
-        private static string BuildNamespacedStatName(string statName)
-        {
-            if (string.IsNullOrEmpty(_prefix))
-            {
-                return statName;
-            }
-
-            return _prefix + "." + statName;
-        }
+        public static void ServiceCheck(string name, Status status, int? timestamp = null, string hostname = null,
+            string[] tags = null, string message = null) =>
+                _dogStatsdService.ServiceCheck(name, status, timestamp, hostname, tags, message);
     }
 }

--- a/src/StatsdClient/IDogStatsd.cs
+++ b/src/StatsdClient/IDogStatsd.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace StatsdClient
+{
+    public interface IDogStatsd
+    {
+        void Configure(StatsdConfig config);
+        void Counter<T>(string statName, T value, double sampleRate = 1, string[] tags = null);
+        void Decrement(string statName, int value = 1, double sampleRate = 1, params string[] tags);
+
+        void Event(string title, string text, string alertType = null, string aggregationKey = null,
+            string sourceType = null, int? dateHappened = null, string priority = null,
+            string hostname = null, string[] tags = null);
+
+        void Gauge<T>(string statName, T value, double sampleRate = 1, string[] tags = null);
+        void Histogram<T>(string statName, T value, double sampleRate = 1, string[] tags = null);
+        void Increment(string statName, int value = 1, double sampleRate = 1, string[] tags = null);
+        void Set<T>(string statName, T value, double sampleRate = 1, string[] tags = null);
+        IDisposable StartTimer(string name, double sampleRate = 1, string[] tags = null);
+        void Time(Action action, string statName, double sampleRate = 1, string[] tags = null);
+        T Time<T>(Func<T> func, string statName, double sampleRate = 1, string[] tags = null);
+        void Timer<T>(string statName, T value, double sampleRate = 1, string[] tags = null);
+
+        void ServiceCheck(string name, Status status, int? timestamp = null, string hostname = null, string[] tags = null,
+            string message = null);
+    }
+}

--- a/src/StatsdClient/StatsdClient.csproj
+++ b/src/StatsdClient/StatsdClient.csproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <Compile Include="DogStatsdService.cs" />
     <Compile Include="ICommandType.cs" />
+    <Compile Include="IDogStatsd.cs" />
     <Compile Include="IRandomGenerator.cs" />
     <Compile Include="IStatsd.cs" />
     <Compile Include="IStatsdUDP.cs" />

--- a/src/StatsdClient/StatsdClient.csproj
+++ b/src/StatsdClient/StatsdClient.csproj
@@ -36,6 +36,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DogStatsdService.cs" />
     <Compile Include="ICommandType.cs" />
     <Compile Include="IRandomGenerator.cs" />
     <Compile Include="IStatsd.cs" />


### PR DESCRIPTION
We are using DataDog and the lack of an abstraction over the static DogStatsd is an impedance in our TDD and test coverage.

Refactoring to provide an interface IDogStatsd and an instance based DogStatsdService for those people using TDD. 

Also still provides the ability to register the instance with your IoC container as a singleton if we want to retain the current "static" functionality