### PR TITLE
[ci] AppVeyor & Mono testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,20 @@
-DogStatsD for C#
-================
+# DogStatsD for C#
+
 [![Build status](https://ci.appveyor.com/api/projects/status/bg8e39b5f9iiavvj/branch/master?svg=true)](https://ci.appveyor.com/project/Datadog/dogstatsd-csharp-client/branch/master)
 
 A C# [DogStatsD](http://docs.datadoghq.com/guides/dogstatsd/) client. DogStatsD
 is an extension of the [StatsD](http://codeascraft.com/2011/02/15/measure-anything-measure-everything/)
 metric server for [Datadog](http://datadoghq.com).
 
-What's new ?
-------------
+## What's new ?
+
 See [CHANGELOG](CHANGELOG.md) for details.
 
-Installation
-------------
+## Installation
 
 Grab the [package from NuGet](https://nuget.org/packages/DogStatsD-CSharp-Client/), or get the source from here and build it yourself.
 
-Usage via the static DogStatsd class:
------------------------------
+## Usage via the static DogStatsd class:
 
 At start of your app, configure the `DogStatsd` class like this:
 
@@ -102,8 +100,7 @@ DogStatsd.Event("SO MUCH SNOW", "Started yesterday and it won't stop !!", alertT
 ```
 
 
-Usage via the Statsd class:
----------------------------
+## Usage via the Statsd class:
 
 In most cases, the static DogStatsd class is probably better to use.
 However, the Statsd is useful when you want to queue up a number of metrics/events to be sent in
@@ -178,14 +175,44 @@ timing, a timer metric containing the time elapsed before the exception
 occurred will be sent or added to the send queue (depending on whether Send or
 Add is being called).
 
-Feedback
---------
+## Testing
+
+### on Windows
+
+1. Build the project
+  ```
+  msbuild src/StatsdClient.sln /p:Configuration=Release /t:Rebuild
+  ```
+
+2. Run tests using NUnit-Console runner
+  ```
+  nunit-console src/Tests/bin/Release/Tests.dll --config=Release
+  ```
+
+### on Linux, OS X
+
+_Requirements:_
+_* Mono JIT compiler (tested with version 4.6.0)_
+
+1. Build the project
+  ```
+  xbuild src/StatsdClient.sln /p:Configuration=Release /t:Rebuild
+  ```
+
+2. Run tests using NUnit-Console runner
+  ```
+  nunit-console src/Tests/bin/Release/Tests.dll --config=Release
+  ```
+
+
+
+
+## Feedback
 
 To suggest a feature, report a bug, or general discussion, head over
 [here](https://github.com/DataDog/statsd-csharp-client/issues).
 
-Credits
--------
+## Credits
 
 dogstatsd-csharp-client is forked from Goncalo Pereira's [original Statsd
 client](https://github.com/goncalopereira/statsd-csharp-client).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,5 @@
+build_script:
+  msbuild src/StatsdClient.sln /p:Configuration=Release /t:Rebuild
+
+test_script:
+  - nunit-console src/Tests/bin/Release/Tests.dll --config=Release

--- a/src/Tests/CommandIntegrationTests.cs
+++ b/src/Tests/CommandIntegrationTests.cs
@@ -48,7 +48,7 @@ namespace Tests
         // then asserts that the passed string is equal to the message received.
         private void AssertWasReceived(string shouldBe, int index = 0)
         {
-            // Stall until the the listener receives a message or times out 
+            // Stall until the the listener receives a message or times out
             while (listenThread.IsAlive) ;
             Assert.AreEqual(shouldBe, udpListener.GetAndClearLastMessages()[index]);
         }
@@ -574,10 +574,9 @@ namespace Tests
             catch (Exception)
             {
                 AssertWasReceivedMatches(@"timer:\d{3}\|ms");
-                Assert.Pass();
             }
         }
-        
+
         [Test]
         public void events_priority_and_date()
         {

--- a/src/Tests/StatsdClient.Tests.csproj
+++ b/src/Tests/StatsdClient.Tests.csproj
@@ -47,10 +47,6 @@
       <HintPath>..\packages\NUnitTestAdapter.1.2\lib\nunit.util.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="NUnit.VisualStudio.TestAdapter">
-      <HintPath>..\packages\NUnitTestAdapter.1.2\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Rhino.Mocks">
       <HintPath>..\StatsdClient\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>
     </Reference>
@@ -96,7 +92,7 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/Tests/StatsdUnitTests.cs
+++ b/src/Tests/StatsdUnitTests.cs
@@ -72,7 +72,6 @@ namespace Tests
             Statsd s = new Statsd(udp, _randomGenerator, _stopwatch);
             udp.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
             s.Send<Statsd.Counting,int>("counter", 5);
-            Assert.Pass();
         }
 
         [Test]
@@ -164,7 +163,6 @@ namespace Tests
             udp.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
             Statsd s = new Statsd(udp);
             s.Send<Statsd.Timing,int>("timer", 5);
-            Assert.Pass();
         }
 
         [Test]
@@ -178,7 +176,7 @@ namespace Tests
             Statsd s = new Statsd(udp, _randomGenerator, _stopwatch);
             s.Send(() => testMethod(), statName);
 
-            udp.AssertWasCalled(x => x.Send("name:500|ms"));       
+            udp.AssertWasCalled(x => x.Send("name:500|ms"));
         }
 
         [Test]
@@ -192,7 +190,7 @@ namespace Tests
             Statsd s = new Statsd(udp, _randomGenerator, _stopwatch);
             s.Send(() => testMethod(), statName, tags: new[] {"tag1:true", "tag2"});
 
-            udp.AssertWasCalled(x => x.Send("name:500|ms|#tag1:true,tag2"));       
+            udp.AssertWasCalled(x => x.Send("name:500|ms|#tag1:true,tag2"));
         }
 
         [Test]
@@ -206,7 +204,7 @@ namespace Tests
             Statsd s = new Statsd(udp, _randomGenerator, _stopwatch);
             s.Send(() => testMethod(), statName, sampleRate: 1.1);
 
-            udp.AssertWasCalled(x => x.Send("name:500|ms|@1.1"));       
+            udp.AssertWasCalled(x => x.Send("name:500|ms|@1.1"));
         }
 
         [Test]
@@ -319,7 +317,7 @@ namespace Tests
         }
 
         // =-=-=-=- GAUGE -=-=-=-=
-        
+
         [Test]
         public void send_gauge()
         {
@@ -375,7 +373,6 @@ namespace Tests
             udp.Stub(x => x.Send(Arg<string>.Is.Anything)).Throw(new Exception());
             Statsd s = new Statsd(udp);
             s.Send<Statsd.Gauge,int>("gauge", 5);
-            Assert.Pass();
         }
 
         [Test]
@@ -438,7 +435,7 @@ namespace Tests
             Assert.That(s.Commands.Count, Is.EqualTo(1));
             Assert.That(s.Commands[0], Is.EqualTo("gauge:5|g|@0.5|#tag1:true,tag2"));
         }
-        
+
         // =-=-=-=- COMBINATION -=-=-=-=
 
         [Test]
@@ -740,7 +737,7 @@ namespace Tests
             Assert.That(s.Commands[0], Is.EqualTo("histogram:5|h|#tag1:true,tag2"));
         }
 
-        
+
         [Test]
         public void add_histogram_with_sample_rate()
         {


### PR DESCRIPTION
## [tests] "mono" friendly tests 
Adapt `StatsdClient.Tests`, so it can run with `mono.`.
* Remove `NUnit.VisualStudio.TestAdapter` requirement
* Do not use `Assert.Pass` (see
  http://www.nunit.org/index.php?p=utilityAsserts&r=2.5), simply allow
  the test to return

##  [ci] add appveyor testing

Enable AppVeyor to run NUnit testing automatically.