### PR TITLE
Allow consumers to set the send buffer size

### DIFF
--- a/src/StatsdClient/DogStatsdService.cs
+++ b/src/StatsdClient/DogStatsdService.cs
@@ -20,7 +20,7 @@ namespace StatsdClient
             Dispose();
             if (!string.IsNullOrEmpty(config.StatsdServerName))
             {
-                var statsdUdp = new StatsdUDP(config.StatsdServerName, config.StatsdPort, config.StatsdMaxUDPPacketSize);
+                var statsdUdp = new StatsdUDP(config.StatsdServerName, config.StatsdPort, config.StatsdMaxUDPPacketSize, config.SendBufferSize);
                 _statsD = new Statsd(statsdUdp);
                 _disposable = statsdUdp;
             }

--- a/src/StatsdClient/StatsdConfig.cs
+++ b/src/StatsdClient/StatsdConfig.cs
@@ -6,6 +6,7 @@
         public int StatsdPort { get; set; }
         public int StatsdMaxUDPPacketSize { get; set; }
         public string Prefix { get; set; }
+        public int? SendBufferSize { get; set; }
 
         public const int DefaultStatsdPort = 8125;
         public const int DefaultStatsdMaxUDPPacketSize = 512;

--- a/src/StatsdClient/StatsdUDP.cs
+++ b/src/StatsdClient/StatsdUDP.cs
@@ -15,13 +15,17 @@ namespace StatsdClient
         private string Name { get; set; }
         private int Port { get; set; }
 
-        public StatsdUDP(string name, int port, int maxUDPPacketSize = StatsdConfig.DefaultStatsdMaxUDPPacketSize)
+        public StatsdUDP(string name, int port, int maxUDPPacketSize = StatsdConfig.DefaultStatsdMaxUDPPacketSize, int? sendBufferSize = null)
         {
             Name = name;
             Port = port;
             MaxUDPPacketSize = maxUDPPacketSize;
 
             UDPSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            if (sendBufferSize != null)
+            {
+                UDPSocket.SendBufferSize = sendBufferSize.Value;
+            }
 
             var ipAddress = GetIpv4Address(name);
 


### PR DESCRIPTION
Occasionally we've been blocking on sending metrics. We'd like to be able to increase the buffer size to avoid this.