### PR TITLE
Fix bug when Dns.GetHostEntry() returns addresses in unexpected order

### DIFF
--- a/src/StatsdClient/StatsdUDP.cs
+++ b/src/StatsdClient/StatsdUDP.cs
@@ -35,15 +35,25 @@ namespace StatsdClient
 
             if (!isValidIPAddress)
             {
+                ipAddress = null;
 #if NET451
                 IPAddress[] addressList = Dns.GetHostEntry(name).AddressList;
 #else
                 IPAddress[] addressList = Dns.GetHostEntryAsync(name).Result.AddressList;
 #endif            
+                //The IPv4 address is usually the last one, but not always
+                for(int positionToTest = addressList.Length - 1; positionToTest >= 0; --positionToTest)
+                {
+                    if(addressList[positionToTest].AddressFamily == AddressFamily.InterNetwork)
+                    {
+                        ipAddress = addressList[positionToTest];
+                        break;
+                    }
+                }
 
-                int positionForIpv4 = addressList.Length - 1;
-
-                ipAddress = addressList[positionForIpv4];
+                //If no IPV4 address is found, throw an exception here, rather than letting it get squashed when encountered at sendtime
+                if(ipAddress == null)
+                    throw new SocketException((int)SocketError.AddressFamilyNotSupported);
             }
             return ipAddress;
         }


### PR DESCRIPTION
We ran into an issue where our metrics weren't sending from some servers, but were sending from others.  We had difficulty tracking it down because no exceptions were showing up in any of our logs.  

It turns out that the issue was with IP address resolution.  After calling Dns.GetHostEntry() in StatsUDP.GetIpv4Address, the code would then return the last element in the array, assuming that it would be the IPv4 address.  However, on the servers where we were encountering this issue, we discovered that Dns.GetHostEntry() was returning IPv4 first, and IPv6 last.  This would then cause errors when metrics got sent over UDP, which was being silently caught and squashed in the try-catch statement in  Statsd.Send().

My proposed fix is to iterate through the returned addresses in reverse to find an IPv4 address.  If no IPv4 address is found, then generate the same exception that would have been squashed at send-time, but allow the user to catch and handle it themselves.

This issue was previously documented by #4 