### PR TITLE
add `TruncateIfTooLong` to `StatsdConfig`

### DIFF
--- a/src/StatsdClient/DogStatsdService.cs
+++ b/src/StatsdClient/DogStatsdService.cs
@@ -22,6 +22,7 @@ namespace StatsdClient
             {
                 var statsdUdp = new StatsdUDP(config.StatsdServerName, config.StatsdPort, config.StatsdMaxUDPPacketSize);
                 _statsD = new Statsd(statsdUdp);
+                _statsD.TruncateIfTooLong = config.StatsdTruncateIfTooLong;
                 _disposable = statsdUdp;
             }
         }

--- a/src/StatsdClient/IStatsd.cs
+++ b/src/StatsdClient/IStatsd.cs
@@ -9,7 +9,7 @@ namespace StatsdClient
         void Send<TCommandType, T>(string name, T value, double sampleRate, params string[] tags) where TCommandType : StatsdClient.Statsd.Metric;
         void Add<TCommandType, T>(string name, T value, double sampleRate, params string[] tags) where TCommandType : StatsdClient.Statsd.Metric;
         void Send(string title, string text, string alertType, string aggregationKey, string sourceType, int? dateHappened, string priority, string hostname, string[] tags, bool truncateIfTooLong = false);
-        void Add(string title, string text, string alertType, string aggregationKey, string sourceType, int? dateHappened, string priority, string hostname, string[] tags);
+        void Add(string title, string text, string alertType, string aggregationKey, string sourceType, int? dateHappened, string priority, string hostname, string[] tags, bool truncateIfTooLong = false);
         void Send(string command);
         void Send();
         void Add(Action actionToTime, string statName, double sampleRate, params string[] tags);
@@ -17,7 +17,7 @@ namespace StatsdClient
         /// <summary>
         /// Add service check
         /// </summary>
-        void Add(string name, int status, int? timestamp, string hostname, string[] tags, string serviceCheckMessage);
+        void Add(string name, int status, int? timestamp, string hostname, string[] tags, string serviceCheckMessage, bool truncateIfTooLong);
         /// <summary>
         /// Send service check
         /// </summary>

--- a/src/StatsdClient/Statsd.cs
+++ b/src/StatsdClient/Statsd.cs
@@ -12,6 +12,7 @@ namespace StatsdClient
         private IRandomGenerator RandomGenerator { get; set; }
 
         private readonly string _prefix;
+        public bool TruncateIfTooLong {get; set; }
 
         public List<string> Commands
         {
@@ -115,7 +116,7 @@ namespace StatsdClient
                 string processedMessage = EscapeMessage(serviceCheckMessage);
 
                 string result = string.Format(CultureInfo.InvariantCulture, "_sc|{0}|{1}", processedName, status);
-               
+
                 if (timestamp != null)
                 {
                     result += string.Format(CultureInfo.InvariantCulture, "|d:{0}", timestamp);
@@ -211,22 +212,25 @@ namespace StatsdClient
             _commands.Add(Metric.GetCommand<TCommandType, T>(_prefix, name, value, sampleRate, tags));
         }
 
-        public void Add(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, string[] tags = null)
+        public void Add(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, string[] tags = null, bool truncateIfTooLong = false)
         {
-            _commands.Add(Event.GetCommand(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, tags));
+            truncateIfTooLong = truncateIfTooLong || TruncateIfTooLong;
+            _commands.Add(Event.GetCommand(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, tags, truncateIfTooLong));
         }
 
         public void Send(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, string[] tags = null, bool truncateIfTooLong = false)
         {
+            truncateIfTooLong = truncateIfTooLong || TruncateIfTooLong;
             Send(Event.GetCommand(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, tags, truncateIfTooLong));
         }
 
         /// <summary>
         /// Add a Service check
         /// </summary>
-        public void Add(string name, int status, int? timestamp = null, string hostname = null, string[] tags = null, string serviceCheckMessage = null)
+        public void Add(string name, int status, int? timestamp = null, string hostname = null, string[] tags = null, string serviceCheckMessage = null, bool truncateIfTooLong = false)
         {
-            _commands.Add(ServiceCheck.GetCommand(name, status, timestamp, hostname, tags, serviceCheckMessage));
+            truncateIfTooLong = truncateIfTooLong || TruncateIfTooLong;
+            _commands.Add(ServiceCheck.GetCommand(name, status, timestamp, hostname, tags, serviceCheckMessage, truncateIfTooLong));
         }
 
         /// <summary>
@@ -234,6 +238,7 @@ namespace StatsdClient
         /// </summary>
         public void Send(string name, int status, int? timestamp = null, string hostname = null, string[] tags = null, string serviceCheckMessage = null, bool truncateIfTooLong = false)
         {
+            truncateIfTooLong = truncateIfTooLong || TruncateIfTooLong;
             Send(ServiceCheck.GetCommand(name, status, timestamp, hostname, tags, serviceCheckMessage, truncateIfTooLong));
         }
 

--- a/src/StatsdClient/StatsdConfig.cs
+++ b/src/StatsdClient/StatsdConfig.cs
@@ -5,6 +5,7 @@
         public string StatsdServerName { get; set; }
         public int StatsdPort { get; set; }
         public int StatsdMaxUDPPacketSize { get; set; }
+        public bool StatsdTruncateIfTooLong { get; set; } = true;
         public string Prefix { get; set; }
 
         public const int DefaultStatsdPort = 8125;

--- a/src/StatsdClient/StatsdUDP.cs
+++ b/src/StatsdClient/StatsdUDP.cs
@@ -40,7 +40,7 @@ namespace StatsdClient
                 IPAddress[] addressList = Dns.GetHostEntry(name).AddressList;
 #else
                 IPAddress[] addressList = Dns.GetHostEntryAsync(name).Result.AddressList;
-#endif            
+#endif
                 //The IPv4 address is usually the last one, but not always
                 for(int positionToTest = addressList.Length - 1; positionToTest >= 0; --positionToTest)
                 {
@@ -89,9 +89,9 @@ namespace StatsdClient
 
                         return; // We're done here if we were able to split the message.
                     }
-                    // At this point we found an oversized message but we weren't able to find a 
-                    // newline to split upon. We'll still send it to the UDP socket, which upon sending an oversized message 
-                    // will fail silently if the user is running in release mode or report a SocketException if the user is 
+                    // At this point we found an oversized message but we weren't able to find a
+                    // newline to split upon. We'll still send it to the UDP socket, which upon sending an oversized message
+                    // will fail silently if the user is running in release mode or report a SocketException if the user is
                     // running in debug mode.
                     // Since we're conservative with our MAX_UDP_PACKET_SIZE, the oversized message might even
                     // be sent without issue.

--- a/tests/StatsdClient.Tests/StatsdUnitTests.cs
+++ b/tests/StatsdClient.Tests/StatsdUnitTests.cs
@@ -625,6 +625,22 @@ namespace StatsdClient.Tests
             Mock.Get(_udp).Verify(x => x.Send(expected));
         }
 
+        [Test]
+        public void send_event_with_statsd_truncation()
+        {
+            Statsd s = new Statsd(_udp, _randomGenerator, _stopwatch);
+            // Enable truncation at Statsd level
+            s.TruncateIfTooLong = true;
+
+            var length = 8 * 1024 - 17; //17 is the number of characters in the final message that is not the text
+            var builder = BuildLongString(length);
+            var text = builder;
+
+            s.Send("title", text + "x");
+            var expected = string.Format("_e{{5,{0}}}:title|{1}", length, text);
+            Mock.Get(_udp).Verify(x => x.Send(expected));
+        }
+
         private static string BuildLongString(int length)
         {
             var builder = new StringBuilder();


### PR DESCRIPTION
Add `TruncateIfTooLong` parameter to `StatsdConfig`. When enabled
(default to `True`), `StatsD` truncates any event and service checks
when their size exceeds 8kB.

Fix https://github.com/DataDog/dogstatsd-csharp-client/issues/48. Help #25.