### PR TITLE
Fix bug with non static DogStatsdService instance and StartTimer method

### DIFF
--- a/src/StatsdClient/DogStatsdService.cs
+++ b/src/StatsdClient/DogStatsdService.cs
@@ -104,7 +104,7 @@ namespace StatsdClient
 
         public IDisposable StartTimer(string name, double sampleRate = 1.0, string[] tags = null)
         {
-            return new MetricsTimer(name, sampleRate, tags);
+            return new MetricsTimer(this, name, sampleRate, tags);
         }
 
         public void Time(Action action, string statName, double sampleRate = 1.0, string[] tags = null)

--- a/src/StatsdClient/MetricsTimer.cs
+++ b/src/StatsdClient/MetricsTimer.cs
@@ -5,14 +5,21 @@ namespace StatsdClient
     public class MetricsTimer : IDisposable
     {
         private readonly string _name;
+        private readonly DogStatsdService _dogStatsd;
         private readonly Stopwatch _stopWatch;
         private bool _disposed;
         private readonly double _sampleRate;
         private readonly string[] _tags;
 
-        public MetricsTimer(string name, double sampleRate = 1.0, string[] tags = null)
+        public MetricsTimer(string name, double sampleRate = 1.0, string[] tags = null) : this(null, name, sampleRate,
+            tags)
+        {            
+        }
+
+        public MetricsTimer(DogStatsdService dogStatsd, string name, double sampleRate = 1.0, string[] tags = null)
         {
             _name = name;
+            _dogStatsd = dogStatsd;
             _stopWatch = new Stopwatch();
             _stopWatch.Start();
             _sampleRate = sampleRate;
@@ -25,7 +32,11 @@ namespace StatsdClient
             {
                 _disposed = true;
                 _stopWatch.Stop();
-                DogStatsd.Timer(_name, _stopWatch.ElapsedMilliseconds(), _sampleRate, _tags);
+
+                if(_dogStatsd == null)
+                    DogStatsd.Timer(_name, _stopWatch.ElapsedMilliseconds(), _sampleRate, _tags);
+                else                
+                    _dogStatsd.Timer(_name, _stopWatch.ElapsedMilliseconds(), _sampleRate, _tags);                
             }
         }
     }

--- a/src/StatsdClient/MetricsTimer.cs
+++ b/src/StatsdClient/MetricsTimer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace StatsdClient
 {
@@ -9,7 +10,6 @@ namespace StatsdClient
         private readonly Stopwatch _stopWatch;
         private bool _disposed;
         private readonly double _sampleRate;
-        private readonly string[] _tags;
 
         public MetricsTimer(string name, double sampleRate = 1.0, string[] tags = null) : this(null, name, sampleRate,
             tags)
@@ -23,7 +23,9 @@ namespace StatsdClient
             _stopWatch = new Stopwatch();
             _stopWatch.Start();
             _sampleRate = sampleRate;
-            _tags = tags;
+            Tags = new List<string>();
+            if(tags != null)
+                Tags.AddRange(tags);
         }
 
         public void Dispose()
@@ -34,10 +36,12 @@ namespace StatsdClient
                 _stopWatch.Stop();
 
                 if(_dogStatsd == null)
-                    DogStatsd.Timer(_name, _stopWatch.ElapsedMilliseconds(), _sampleRate, _tags);
+                    DogStatsd.Timer(_name, _stopWatch.ElapsedMilliseconds(), _sampleRate, Tags.ToArray());
                 else                
-                    _dogStatsd.Timer(_name, _stopWatch.ElapsedMilliseconds(), _sampleRate, _tags);                
+                    _dogStatsd.Timer(_name, _stopWatch.ElapsedMilliseconds(), _sampleRate, Tags.ToArray());                
             }
         }
+
+        public List<string> Tags { get; set; }
     }
 }

--- a/tests/StatsdClient.Tests/DogStatsdServiceTests.cs
+++ b/tests/StatsdClient.Tests/DogStatsdServiceTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using NUnit.Framework;
+using StatsdClient;
+using Tests.Helpers;
+
+
+namespace Tests
+{
+    [TestFixture]
+    public class DogStatsdServiceConfigurationTest
+    {
+        private List<string> ReceiveData(IDogStatsd dogStatsdInstance, string testServerName, int testPort, Action sendData)
+        {
+            using (var udpListener = new UdpListener(testServerName, testPort))
+            {
+                var listenThread = new Thread(udpListener.Listen);
+                listenThread.Start();
+
+                sendData();
+
+                while (listenThread.IsAlive) ;
+
+                return udpListener.GetAndClearLastMessages();  
+            }
+        }
+
+        
+
+        //[Test]
+        //public void throw_exception_when_no_config_provided()
+        //{
+        //    StatsdConfig metricsConfig = null;
+        //    Assert.Throws<ArgumentNullException>(() => StatsdClient.DogStatsd.Configure(metricsConfig));
+        //}
+
+        //[Test]
+        //public void throw_exception_when_no_hostname_provided()
+        //{
+        //    var metricsConfig = new StatsdConfig { };
+        //    Assert.Throws<ArgumentNullException>(() => StatsdClient.DogStatsd.Configure(metricsConfig));
+        //}
+
+        [Test]
+        public void default_port_is_8125()
+        {
+            using (var nonStaticServiceInstance = new DogStatsdService())
+            {
+                var metricsConfig = new StatsdConfig
+                {
+                    StatsdServerName = "127.0.0.1"
+                };
+
+                nonStaticServiceInstance.Configure(metricsConfig);
+                var receivedData = ReceiveData(nonStaticServiceInstance, "127.0.0.1", 8125,
+                    () => { nonStaticServiceInstance.Increment("test"); });
+
+                Assert.AreEqual(new List<string> {"test:1|c"}, receivedData);
+            }
+        }
+
+        [Test]
+        public void setting_port()
+        {
+            using (var nonStaticServiceInstance = new DogStatsdService())
+            {
+                var metricsConfig = new StatsdConfig
+                {
+                    StatsdServerName = "127.0.0.1",
+                    StatsdPort = 8126
+                };
+
+                nonStaticServiceInstance.Configure(metricsConfig);
+                var receivedData = ReceiveData(nonStaticServiceInstance, "127.0.0.1", 8126,
+                    () => { nonStaticServiceInstance.Increment("test"); });
+
+                Assert.AreEqual(new List<string> { "test:1|c" }, receivedData);
+            }            
+        }
+
+        [Test]
+        public void setting_port_listen_on_other_port_should_return_no_data()
+        {
+            using (var nonStaticServiceInstance = new DogStatsdService())
+            {
+                var metricsConfig = new StatsdConfig
+                {
+                    StatsdServerName = "127.0.0.1",
+                    StatsdPort = 8126
+                };
+                nonStaticServiceInstance.Configure(metricsConfig);
+                var receivedData = ReceiveData(nonStaticServiceInstance, "127.0.0.1", 8125,
+                    () => { nonStaticServiceInstance.Increment("test"); });
+
+                Assert.AreEqual(0, receivedData.Count);
+            }       
+        }
+
+
+        [Test]
+        public void setting_prefix()
+        {
+            using (var nonStaticServiceInstance = new DogStatsdService())
+            {
+                var metricsConfig = new StatsdConfig
+                {
+                    StatsdServerName = "127.0.0.1",
+                    StatsdPort = 8129,
+                    Prefix = "prefix"
+                };
+                nonStaticServiceInstance.Configure(metricsConfig);
+                var receivedData = ReceiveData(nonStaticServiceInstance, "127.0.0.1", 8129,
+                    () => { nonStaticServiceInstance.Increment("test"); });
+
+                Assert.AreEqual(new List<string> { "prefix.test:1|c" }, receivedData);
+            }           
+        }
+
+        [Test]
+        public void setting_prefix_starttimer()
+        {
+            using (var nonStaticServiceInstance = new DogStatsdService())
+            {
+                var metricsConfig = new StatsdConfig
+                {
+                    StatsdServerName = "127.0.0.1",
+                    StatsdPort = 8130,
+                    Prefix = "prefix"
+                };
+                nonStaticServiceInstance.Configure(metricsConfig);
+                var receivedData = ReceiveData(nonStaticServiceInstance, "127.0.0.1", 8130,
+                    () => {
+                        using (nonStaticServiceInstance.StartTimer("timer.test"))
+                        {
+                            Thread.Sleep(100);
+                        }
+                    });
+
+                Assert.AreEqual(1, receivedData.Count);
+
+                var metricResultSplit = receivedData[0].Split(':');
+
+                Assert.AreEqual(2, metricResultSplit.Length);
+
+                var metricNameWithPrefix = metricResultSplit[0];
+                var metricTimeAndType = metricResultSplit[1];
+
+                Assert.AreEqual("prefix.timer.test", metricNameWithPrefix);
+
+                var metricTimeInMsSplit = metricTimeAndType.Split('|');
+                Assert.AreEqual(2, metricTimeInMsSplit.Length);
+
+                var metricTimeInMs = Convert.ToInt32(metricTimeInMsSplit[0]);
+                Assert.IsTrue((metricTimeInMs >= 100), "Processing should have taken at least 100ms");
+                Assert.IsTrue((metricTimeInMs < 110), "Timer reported 10% higher than time taken in action");
+            }  
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/DataDog/dogstatsd-csharp-client/issues/62

- Added constructor option to pass current DogStatsdService instance into MetricsTimer (though left existing constructor/static support since I'm not sure how this is being used by others)
- Added tests for DogStatsdService as there were none before.  