### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Add is being called).
   ```
 2. Run the tests
   ```
-  dotnet test tests/StatsdClient.Tests/`
+  dotnet test tests/StatsdClient.Tests/
   ```
 
 ## Feedback


### PR DESCRIPTION
There appears to be an extra backtick in the example test command.

Thanks! 🙌 