### PR TITLE
Add environment variables support for Client configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,19 @@ using StatsdClient;
 
 var dogstatsdConfig = new StatsdConfig
 {
-    StatsdServerName = "127.0.0.1",
-    StatsdPort = 8125, // Optional; default is 8125
+    StatsdServerName = "127.0.0.1", // Optional if DD_AGENT_HOST environment variable set
+    StatsdPort = 8125, // Optional; If not present takes the DD_DOGSTATSD_PORT environment variable value, else default is 8125
     Prefix = "myApp" // Optional; by default no prefix will be prepended
+    ConstantTags = ["foo:bar"] // Optional
 };
 
 StatsdClient.DogStatsd.Configure(dogstatsdConfig);
 ```
+
+Supported environment variables:
+
+* The client can use the `DD_AGENT_HOST` and (optionally) the `DD_DOGSTATSD_PORT` environment variables to build the target address if the `addr` parameter is empty.
+* If the `DD_ENTITY_ID` enviroment variable is found, its value will be injected as a global `dd.internal.entity_id` tag. This tag will be used by the Datadog Agent to insert container tags to the metrics.
 
 Where `StatsdServerName` is the hostname or address of the StatsD server, `StatsdPort` is the optional DogStatsD port number, and `Prefix` is an optional string that is prepended to all metrics.
 

--- a/src/StatsdClient/StatsdConfig.cs
+++ b/src/StatsdClient/StatsdConfig.cs
@@ -8,12 +8,17 @@
         public bool StatsdTruncateIfTooLong { get; set; } = true;
         public string Prefix { get; set; }
 
+        public string[] ConstantTags { get; set; }
         public const int DefaultStatsdPort = 8125;
         public const int DefaultStatsdMaxUDPPacketSize = 512;
 
+        public const string DD_ENTITY_ID_ENV_VAR = "DD_ENTITY_ID";
+        public const string DD_DOGSTATSD_PORT_ENV_VAR = "DD_DOGSTATSD_PORT";
+        public const string DD_AGENT_HOST_ENV_VAR = "DD_AGENT_HOST";
+
         public StatsdConfig()
         {
-            StatsdPort = DefaultStatsdPort;
+            StatsdPort = -1;
             StatsdMaxUDPPacketSize = DefaultStatsdMaxUDPPacketSize;
         }
     }

--- a/src/StatsdClient/StatsdConfig.cs
+++ b/src/StatsdClient/StatsdConfig.cs
@@ -18,7 +18,7 @@
 
         public StatsdConfig()
         {
-            StatsdPort = -1;
+            StatsdPort = 0;
             StatsdMaxUDPPacketSize = DefaultStatsdMaxUDPPacketSize;
         }
     }

--- a/src/StatsdClient/StatsdUDP.cs
+++ b/src/StatsdClient/StatsdUDP.cs
@@ -15,19 +15,54 @@ namespace StatsdClient
         private string Name { get; set; }
         private int Port { get; set; }
 
+        public StatsdUDP(int maxUDPPacketSize = StatsdConfig.DefaultStatsdMaxUDPPacketSize)
+        : this(GetHostNameFromEnvVar(),GetPortFromEnvVar(StatsdConfig.DefaultStatsdPort),maxUDPPacketSize)
+        {
+        }
         public StatsdUDP(string name, int port, int maxUDPPacketSize = StatsdConfig.DefaultStatsdMaxUDPPacketSize)
         {
-            Name = name;
             Port = port;
+            if (Port == -1)
+            {
+                Port = GetPortFromEnvVar(StatsdConfig.DefaultStatsdPort);
+            }
+            Name = name;
+            if (string.IsNullOrEmpty(Name))
+            {
+                Name = GetHostNameFromEnvVar();
+            }
+
             MaxUDPPacketSize = maxUDPPacketSize;
 
             UDPSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
 
-            var ipAddress = GetIpv4Address(name);
+            var ipAddress = GetIpv4Address(Name);
 
             IPEndpoint = new IPEndPoint(ipAddress, Port);
         }
 
+        private static string GetHostNameFromEnvVar()
+        {
+            return Environment.GetEnvironmentVariable(StatsdConfig.DD_AGENT_HOST_ENV_VAR);
+        }
+
+        private static int GetPortFromEnvVar(int defaultValue)
+        {
+            int port = defaultValue;
+            string portString = Environment.GetEnvironmentVariable(StatsdConfig.DD_DOGSTATSD_PORT_ENV_VAR);
+            if (portString != null)
+            {
+                try
+                {
+                    port = Int32.Parse(portString);
+                }
+                catch (FormatException)
+                {
+                    throw new ArgumentException("Environment Variable 'DD_DOGSTATSD_PORT' bad format");
+                }
+            }
+            return port;
+        }
         private IPAddress GetIpv4Address(string name)
         {
             IPAddress ipAddress;

--- a/src/StatsdClient/StatsdUDP.cs
+++ b/src/StatsdClient/StatsdUDP.cs
@@ -19,10 +19,10 @@ namespace StatsdClient
         : this(GetHostNameFromEnvVar(),GetPortFromEnvVar(StatsdConfig.DefaultStatsdPort),maxUDPPacketSize)
         {
         }
-        public StatsdUDP(string name, int port, int maxUDPPacketSize = StatsdConfig.DefaultStatsdMaxUDPPacketSize)
+        public StatsdUDP(string name = null, int port = 0, int maxUDPPacketSize = StatsdConfig.DefaultStatsdMaxUDPPacketSize)
         {
             Port = port;
-            if (Port == -1)
+            if (Port == 0)
             {
                 Port = GetPortFromEnvVar(StatsdConfig.DefaultStatsdPort);
             }


### PR DESCRIPTION
Support of 3 environment variables for Client configuration:
- "DD_AGENT_HOST" used to provide the Agent hostname.
- "DD_DOGSTATSD_PORT" used to provide the DogStatsD port.
- "DD_ENTITY_ID" used to provide an identifier to the Client.