### PR TITLE
Fix a multithreading issue with SendAsync.

### DIFF
--- a/src/StatsdClient/Statsd.cs
+++ b/src/StatsdClient/Statsd.cs
@@ -329,10 +329,11 @@ namespace StatsdClient
         {
             try
             {
-                Udp.Send(command);
                 // clear buffer (keep existing behavior)
                 if (Commands.Count > 0)
                     Commands = new List<string>();
+
+                Udp.Send(command);
             }
             catch (Exception e)
             {
@@ -344,10 +345,11 @@ namespace StatsdClient
         {
             try
             {
-                await Udp.SendAsync(command).ConfigureAwait(false);
                 // clear buffer (keep existing behavior)
                 if (Commands.Count > 0)
                     Commands = new List<string>();
+
+                await Udp.SendAsync(command).ConfigureAwait(false);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Fixing https://github.com/DataDog/dogstatsd-csharp-client/pull/59#discussion_r339920502

Consider the following code:

```C#
var task = statsd.SendAsync("Something");
// Call a method that mutates `Commands` or `_commands` leads to a race condition.
await task;
```

`statsd.SendAsync` might return to the caller and then call `Commands = new List<string>();` from another thread.

This PR calls `Commands = new List<string>();` before any await calls to make sure `Commands = new List<string>();` is called before `SendAsync` returns to the caller.

The update in `Statsd.Send` is not required but done to keep consistency between `Send` and `SendAsync`.

Note to reviewers: Please review carefully these changes.
