### PR TITLE
Do not use a compile time check to enable UDS.

### DIFF
--- a/src/StatsdClient/StatsdUnixDomainSocket.cs
+++ b/src/StatsdClient/StatsdUnixDomainSocket.cs
@@ -22,15 +22,18 @@ namespace StatsdClient
 
         public StatsdUnixDomainSocket(string unixSocket, int maxPacketSize)
         {
-#if OS_WINDOWS
-#pragma warning disable CS0162 // Unreachable code detected
-            throw new NotSupportedException("Unix domain socket is not supported on Windows.");
-#endif
             if (unixSocket == null || !unixSocket.StartsWith(StatsdUnixDomainSocket.UnixDomainSocketPrefix))
                 throw new ArgumentException($"{nameof(unixSocket)} must start with {StatsdUnixDomainSocket.UnixDomainSocketPrefix}");
             unixSocket = unixSocket.Substring(StatsdUnixDomainSocket.UnixDomainSocketPrefix.Length);
 
-            _socket = new Socket(AddressFamily.Unix, SocketType.Dgram, ProtocolType.IP);
+            try
+            {
+                _socket = new Socket(AddressFamily.Unix, SocketType.Dgram, ProtocolType.IP);
+            }
+            catch (SocketException e)
+            {
+                throw new NotSupportedException("Unix domain socket is not supported on your operating system.", e);
+            }
             _endPoint = new UnixEndPoint(unixSocket);
             _maxPacketSize = maxPacketSize;
             _socket.Blocking = false;


### PR DESCRIPTION
When building a Nuget package on Windows `OS_WINDOWS` is defined and so Unix domain socket cannot be used on Unix platform.

This PR checks if we can create a UDS socket instead of using a compilation check. 