### PR TITLE
Add globalTags to the Telemetry.

### DIFF
--- a/src/StatsdClient/Bufferize/IStatsBufferizeFactory.cs
+++ b/src/StatsdClient/Bufferize/IStatsBufferizeFactory.cs
@@ -22,5 +22,11 @@ namespace StatsdClient.Bufferize
         StatsSender CreateUnixDomainSocketStatsSender(
             UnixEndPoint endPoint,
             TimeSpan? udsBufferFullBlockDuration);
+
+        Telemetry CreateTelemetry(
+            string assemblyVersion,
+            TimeSpan flushInterval,
+            IStatsSender statsSender,
+            string[] globalTags);
     }
 }

--- a/src/StatsdClient/Bufferize/StatsBufferizeFactory.cs
+++ b/src/StatsdClient/Bufferize/StatsBufferizeFactory.cs
@@ -32,5 +32,10 @@ namespace StatsdClient.Bufferize
         {
             return StatsSender.CreateUnixDomainSocketStatsSender(endPoint, udsBufferFullBlockDuration);
         }
+
+        public Telemetry CreateTelemetry(string assemblyVersion, TimeSpan flushInterval, IStatsSender statsSender, string[] globalTags)
+        {
+            return new Telemetry(assemblyVersion, flushInterval, statsSender, globalTags);
+        }
     }
 }

--- a/src/StatsdClient/Dogstatsd.cs
+++ b/src/StatsdClient/Dogstatsd.cs
@@ -222,6 +222,10 @@ namespace StatsdClient
             string message = null) =>
                 _dogStatsdService.ServiceCheck(name, status, timestamp, hostname, tags, message);
 
+        /// <summary>
+        /// Disposes the instance of DogStatsdService.
+        /// Flushes all metrics.
+        /// </summary>
         public static void Dispose()
         {
             _dogStatsdService.Dispose();

--- a/src/StatsdClient/Telemetry.cs
+++ b/src/StatsdClient/Telemetry.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using StatsdClient.Bufferize;
 
@@ -28,7 +29,11 @@ namespace StatsdClient
         {
         }
 
-        public Telemetry(string assemblyVersion, TimeSpan flushInterval, IStatsSender statsSender)
+        public Telemetry(
+            string assemblyVersion,
+            TimeSpan flushInterval,
+            IStatsSender statsSender,
+            string[] globalTags)
         {
             _optionalStatsSender = statsSender;
 
@@ -40,7 +45,9 @@ namespace StatsdClient
                 default: transport = statsSender.TransportType.ToString(); break;
             }
 
-            _optionalTags = new[] { "client:csharp", $"client_version:{assemblyVersion}", $"client_transport:{transport}" };
+            var optionalTags = new List<string> { "client:csharp", $"client_version:{assemblyVersion}", $"client_transport:{transport}" };
+            optionalTags.AddRange(globalTags);
+            _optionalTags = optionalTags.ToArray();
 
             _optionalTimer = new Timer(
                 _ => Flush(),

--- a/tests/StatsdClient.Tests/TelemetryTests.cs
+++ b/tests/StatsdClient.Tests/TelemetryTests.cs
@@ -19,7 +19,11 @@ namespace Tests
             var statsSender = new Mock<IStatsSender>();
             statsSender.Setup(s => s.Send(It.IsAny<byte[]>(), It.IsAny<int>()))
                 .Callback<byte[], int>((bytes, l) => _metrics.Add(Encoding.UTF8.GetString(bytes, 0, l)));
-            _telemetry = new Telemetry("1.0.0.0", TimeSpan.FromHours(1), statsSender.Object);
+            _telemetry = new Telemetry(
+                "1.0.0.0",
+                TimeSpan.FromHours(1),
+                statsSender.Object,
+                new string[] { "globalTagKey:globalTagValue" });
         }
 
         [TearDown]
@@ -98,7 +102,8 @@ namespace Tests
             _telemetry.Flush();
             Assert.AreEqual(
                 "datadog.dogstatsd.client.metrics:1|c|#" +
-                "client:csharp,client_version:1.0.0.0,client_transport:uds", _metrics[0]);
+                "client:csharp,client_version:1.0.0.0,client_transport:uds," +
+                "globalTagKey:globalTagValue", _metrics[0]);
         }
 
         private void AssertTelemetryReceived(Dictionary<string, int> expectedResults)


### PR DESCRIPTION
Add `ConstantTags` and `dd.internal.entity_id` tag to the telemetry.

Note: Need to merge other PRS to fix failed tests.