### PR TITLE
Fix High CPU Usage.

### DIFF
--- a/src/StatsdClient/Bufferize/StatsBufferize.cs
+++ b/src/StatsdClient/Bufferize/StatsBufferize.cs
@@ -83,8 +83,7 @@ namespace StatsdClient.Bufferize
                 {
                     this._bufferBuilder.HandleBufferAndReset();
 
-                    // No need to wait as sending the value takes time.
-                    return false;
+                    return true;
                 }
 
                 return true;


### PR DESCRIPTION
Fix https://github.com/DataDog/dogstatsd-csharp-client/issues/119.

If few metrics are sent, `StatsBufferize.OnIdle()` can result in a spin loop.
This PR make sure the thread is slept in that case.