### PR TITLE
Replace`Statsd` class by several smaller components. 

### DIFF
--- a/src/StatsdClient/Bufferize/StatsBufferize.cs
+++ b/src/StatsdClient/Bufferize/StatsBufferize.cs
@@ -7,7 +7,7 @@ namespace StatsdClient.Bufferize
     /// <summary>
     /// StatsBufferize bufferizes metrics before sending them.
     /// </summary>
-    internal class StatsBufferize : IStatsdUDP, IDisposable
+    internal class StatsBufferize : IDisposable
     {
         private readonly AsynchronousWorker<string> _worker;
         private readonly Telemetry _telemetry;
@@ -43,11 +43,6 @@ namespace StatsdClient.Bufferize
         public void Dispose()
         {
             this._worker.Dispose();
-        }
-
-        public Task SendAsync(string command)
-        {
-            throw new NotSupportedException();
         }
 
         private class WorkerHandler : IAsynchronousWorkerHandler<string>

--- a/src/StatsdClient/DogStatsdService.cs
+++ b/src/StatsdClient/DogStatsdService.cs
@@ -74,7 +74,7 @@ namespace StatsdClient
         /// <typeparam name="T">The type of the value.</typeparam>
         public void Counter<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.SendMetric(MetricType.Counting, statName, value, sampleRate, tags);
+            _metricsSender?.SendMetric(MetricType.Count, statName, value, sampleRate, tags);
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace StatsdClient
         /// <param name="tags">Array of tags to be added to the data.</param>
         public void Increment(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.SendMetric(MetricType.Counting, statName, value, sampleRate, tags);
+            _metricsSender?.SendMetric(MetricType.Count, statName, value, sampleRate, tags);
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace StatsdClient
         /// <param name="tags">Array of tags to be added to the data.</param>
         public void Decrement(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.SendMetric(MetricType.Counting, statName, -value, sampleRate, tags);
+            _metricsSender?.SendMetric(MetricType.Count, statName, -value, sampleRate, tags);
         }
 
         /// <summary>

--- a/src/StatsdClient/DogStatsdService.cs
+++ b/src/StatsdClient/DogStatsdService.cs
@@ -61,7 +61,7 @@ namespace StatsdClient
         /// <param name="tags">Array of tags to be added to the data.</param>
         public void Event(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, string[] tags = null)
         {
-            _metricsSender?.Send(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, tags);
+            _metricsSender?.SendEvent(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, tags);
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace StatsdClient
         /// <typeparam name="T">The type of the value.</typeparam>
         public void Counter<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send(MetricType.Counting, statName, value, sampleRate, tags);
+            _metricsSender?.SendMetric(MetricType.Counting, statName, value, sampleRate, tags);
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace StatsdClient
         /// <param name="tags">Array of tags to be added to the data.</param>
         public void Increment(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send(MetricType.Counting, statName, value, sampleRate, tags);
+            _metricsSender?.SendMetric(MetricType.Counting, statName, value, sampleRate, tags);
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace StatsdClient
         /// <param name="tags">Array of tags to be added to the data.</param>
         public void Decrement(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send(MetricType.Counting, statName, -value, sampleRate, tags);
+            _metricsSender?.SendMetric(MetricType.Counting, statName, -value, sampleRate, tags);
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace StatsdClient
         /// <typeparam name="T">The type of the value.</typeparam>
         public void Gauge<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send(MetricType.Gauge, statName, value, sampleRate, tags);
+            _metricsSender?.SendMetric(MetricType.Gauge, statName, value, sampleRate, tags);
         }
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace StatsdClient
         /// <typeparam name="T">The type of the value.</typeparam>
         public void Histogram<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send(MetricType.Histogram, statName, value, sampleRate, tags);
+            _metricsSender?.SendMetric(MetricType.Histogram, statName, value, sampleRate, tags);
         }
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace StatsdClient
         /// <typeparam name="T">The type of the value.</typeparam>
         public void Distribution<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send(MetricType.Distribution, statName, value, sampleRate, tags);
+            _metricsSender?.SendMetric(MetricType.Distribution, statName, value, sampleRate, tags);
         }
 
         /// <summary>
@@ -150,7 +150,7 @@ namespace StatsdClient
         /// <typeparam name="T">The type of the value.</typeparam>
         public void Set<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send(MetricType.Set, statName, value, sampleRate, tags);
+            _metricsSender?.SendMetric(MetricType.Set, statName, value, sampleRate, tags);
         }
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace StatsdClient
         /// <typeparam name="T">The type of value parameter.</typeparam>
         public void Timer<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send(MetricType.Timing, statName, value, sampleRate, tags);
+            _metricsSender?.SendMetric(MetricType.Timing, statName, value, sampleRate, tags);
         }
 
         /// <summary>
@@ -230,7 +230,7 @@ namespace StatsdClient
         /// <param name="message">Additional information or a description of why the status occurred.</param>
         public void ServiceCheck(string name, Status status, int? timestamp = null, string hostname = null, string[] tags = null, string message = null)
         {
-            _metricsSender?.Send(name, (int)status, timestamp, hostname, tags, message);
+            _metricsSender?.SendServiceCheck(name, (int)status, timestamp, hostname, tags, message);
         }
 
         /// <summary>

--- a/src/StatsdClient/DogStatsdService.cs
+++ b/src/StatsdClient/DogStatsdService.cs
@@ -1,5 +1,6 @@
 using System;
 using StatsdClient.Bufferize;
+using static StatsdClient.MetricsSender;
 
 namespace StatsdClient
 {
@@ -77,7 +78,7 @@ namespace StatsdClient
         /// <typeparam name="T">The type of the value.</typeparam>
         public void Counter<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send<MetricsSender.Counting, T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
+            _metricsSender?.Send(MetricType.Counting, BuildNamespacedStatName(statName), value, sampleRate, tags);
         }
 
         /// <summary>
@@ -89,7 +90,7 @@ namespace StatsdClient
         /// <param name="tags">Array of tags to be added to the data.</param>
         public void Increment(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send<MetricsSender.Counting, int>(BuildNamespacedStatName(statName), value, sampleRate, tags);
+            _metricsSender?.Send(MetricType.Counting, BuildNamespacedStatName(statName), value, sampleRate, tags);
         }
 
         /// <summary>
@@ -101,7 +102,7 @@ namespace StatsdClient
         /// <param name="tags">Array of tags to be added to the data.</param>
         public void Decrement(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send<MetricsSender.Counting, int>(BuildNamespacedStatName(statName), -value, sampleRate, tags);
+            _metricsSender?.Send(MetricType.Counting, BuildNamespacedStatName(statName), -value, sampleRate, tags);
         }
 
         /// <summary>
@@ -114,7 +115,7 @@ namespace StatsdClient
         /// <typeparam name="T">The type of the value.</typeparam>
         public void Gauge<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send<MetricsSender.Gauge, T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
+            _metricsSender?.Send(MetricType.Gauge, BuildNamespacedStatName(statName), value, sampleRate, tags);
         }
 
         /// <summary>
@@ -127,7 +128,7 @@ namespace StatsdClient
         /// <typeparam name="T">The type of the value.</typeparam>
         public void Histogram<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send<MetricsSender.Histogram, T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
+            _metricsSender?.Send(MetricType.Histogram, BuildNamespacedStatName(statName), value, sampleRate, tags);
         }
 
         /// <summary>
@@ -140,7 +141,7 @@ namespace StatsdClient
         /// <typeparam name="T">The type of the value.</typeparam>
         public void Distribution<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send<MetricsSender.Distribution, T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
+            _metricsSender?.Send(MetricType.Distribution, BuildNamespacedStatName(statName), value, sampleRate, tags);
         }
 
         /// <summary>
@@ -153,7 +154,7 @@ namespace StatsdClient
         /// <typeparam name="T">The type of the value.</typeparam>
         public void Set<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send<MetricsSender.Set, T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
+            _metricsSender?.Send(MetricType.Set, BuildNamespacedStatName(statName), value, sampleRate, tags);
         }
 
         /// <summary>
@@ -166,7 +167,7 @@ namespace StatsdClient
         /// <typeparam name="T">The type of value parameter.</typeparam>
         public void Timer<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send<MetricsSender.Timing, T>(BuildNamespacedStatName(statName), value, sampleRate, tags);
+            _metricsSender?.Send(MetricType.Timing, BuildNamespacedStatName(statName), value, sampleRate, tags);
         }
 
         /// <summary>

--- a/src/StatsdClient/DogStatsdService.cs
+++ b/src/StatsdClient/DogStatsdService.cs
@@ -1,6 +1,5 @@
 using System;
 using StatsdClient.Bufferize;
-using static StatsdClient.MetricsSender;
 
 namespace StatsdClient
 {
@@ -13,7 +12,6 @@ namespace StatsdClient
         private StatsdBuilder _statsdBuilder = new StatsdBuilder(new StatsBufferizeFactory());
         private MetricsSender _metricsSender;
         private StatsdData _statsdData;
-        private string _prefix;
         private StatsdConfig _config;
 
         /// <summary>
@@ -45,8 +43,6 @@ namespace StatsdClient
             }
 
             _config = config;
-            _prefix = config.Prefix;
-
             _statsdData = _statsdBuilder.BuildStatsData(config);
             _metricsSender = _statsdData.MetricsSender;
         }
@@ -78,7 +74,7 @@ namespace StatsdClient
         /// <typeparam name="T">The type of the value.</typeparam>
         public void Counter<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send(MetricType.Counting, BuildNamespacedStatName(statName), value, sampleRate, tags);
+            _metricsSender?.Send(MetricType.Counting, statName, value, sampleRate, tags);
         }
 
         /// <summary>
@@ -90,7 +86,7 @@ namespace StatsdClient
         /// <param name="tags">Array of tags to be added to the data.</param>
         public void Increment(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send(MetricType.Counting, BuildNamespacedStatName(statName), value, sampleRate, tags);
+            _metricsSender?.Send(MetricType.Counting, statName, value, sampleRate, tags);
         }
 
         /// <summary>
@@ -102,7 +98,7 @@ namespace StatsdClient
         /// <param name="tags">Array of tags to be added to the data.</param>
         public void Decrement(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send(MetricType.Counting, BuildNamespacedStatName(statName), -value, sampleRate, tags);
+            _metricsSender?.Send(MetricType.Counting, statName, -value, sampleRate, tags);
         }
 
         /// <summary>
@@ -115,7 +111,7 @@ namespace StatsdClient
         /// <typeparam name="T">The type of the value.</typeparam>
         public void Gauge<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send(MetricType.Gauge, BuildNamespacedStatName(statName), value, sampleRate, tags);
+            _metricsSender?.Send(MetricType.Gauge, statName, value, sampleRate, tags);
         }
 
         /// <summary>
@@ -128,7 +124,7 @@ namespace StatsdClient
         /// <typeparam name="T">The type of the value.</typeparam>
         public void Histogram<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send(MetricType.Histogram, BuildNamespacedStatName(statName), value, sampleRate, tags);
+            _metricsSender?.Send(MetricType.Histogram, statName, value, sampleRate, tags);
         }
 
         /// <summary>
@@ -141,7 +137,7 @@ namespace StatsdClient
         /// <typeparam name="T">The type of the value.</typeparam>
         public void Distribution<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send(MetricType.Distribution, BuildNamespacedStatName(statName), value, sampleRate, tags);
+            _metricsSender?.Send(MetricType.Distribution, statName, value, sampleRate, tags);
         }
 
         /// <summary>
@@ -154,7 +150,7 @@ namespace StatsdClient
         /// <typeparam name="T">The type of the value.</typeparam>
         public void Set<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send(MetricType.Set, BuildNamespacedStatName(statName), value, sampleRate, tags);
+            _metricsSender?.Send(MetricType.Set, statName, value, sampleRate, tags);
         }
 
         /// <summary>
@@ -167,7 +163,7 @@ namespace StatsdClient
         /// <typeparam name="T">The type of value parameter.</typeparam>
         public void Timer<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.Send(MetricType.Timing, BuildNamespacedStatName(statName), value, sampleRate, tags);
+            _metricsSender?.Send(MetricType.Timing, statName, value, sampleRate, tags);
         }
 
         /// <summary>
@@ -197,7 +193,7 @@ namespace StatsdClient
             }
             else
             {
-                _metricsSender.Send(action, BuildNamespacedStatName(statName), sampleRate, tags);
+                _metricsSender.Send(action, statName, sampleRate, tags);
             }
         }
 
@@ -245,16 +241,6 @@ namespace StatsdClient
         {
             _statsdData?.Dispose();
             _statsdData = null;
-        }
-
-        private string BuildNamespacedStatName(string statName)
-        {
-            if (string.IsNullOrEmpty(_prefix))
-            {
-                return statName;
-            }
-
-            return _prefix + "." + statName;
         }
     }
 }

--- a/src/StatsdClient/MetricSerializer.cs
+++ b/src/StatsdClient/MetricSerializer.cs
@@ -1,0 +1,306 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using StatsdClient.Bufferize;
+
+namespace StatsdClientTpm
+{
+    internal class MetricsSender
+    {
+        private static readonly string[] EmptyStringArray = new string[0];
+        private readonly string _prefix;
+        private readonly string[] _constantTags;
+        private readonly Telemetry _optionalTelemetry;
+        private readonly StatsBufferize _statsBufferize;
+
+        internal MetricsSender(
+                    StatsBufferize statsBufferize,
+                    IRandomGenerator randomGenerator,
+                    IStopWatchFactory stopwatchFactory,
+                    string prefix,
+                    string[] constantTags,
+                    Telemetry optionalTelemetry)
+        {
+            StopwatchFactory = stopwatchFactory;
+            _statsBufferize = statsBufferize;
+            RandomGenerator = randomGenerator;
+            _prefix = prefix;
+            _optionalTelemetry = optionalTelemetry;
+
+            // copy array to prevent changes, coalesce to empty array
+            _constantTags = constantTags?.ToArray() ?? EmptyStringArray;
+        }
+
+        public enum MetricType
+        {
+            Counting,
+            Timing,
+            Gauge,
+            Histogram,
+            Distribution,
+            Meter,
+            Set,
+        }
+
+        public bool TruncateIfTooLong { get; set; }
+
+        private IStopWatchFactory StopwatchFactory { get; set; }
+
+        private IRandomGenerator RandomGenerator { get; set; }
+
+        public void Send(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, string[] tags = null, bool truncateIfTooLong = false)
+        {
+            truncateIfTooLong = truncateIfTooLong || TruncateIfTooLong;
+            Send(Event.GetCommand(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, _constantTags, tags, truncateIfTooLong));
+            _optionalTelemetry?.OnEventSent();
+        }
+
+        public void Send(string name, int status, int? timestamp = null, string hostname = null, string[] tags = null, string serviceCheckMessage = null, bool truncateIfTooLong = false)
+        {
+            truncateIfTooLong = truncateIfTooLong || TruncateIfTooLong;
+            Send(ServiceCheck.GetCommand(name, status, timestamp, hostname, _constantTags, tags, serviceCheckMessage, truncateIfTooLong));
+            _optionalTelemetry?.OnServiceCheckSent();
+        }
+
+        public void Send<T>(MetricType metricType, string name, T value, double sampleRate = 1.0, string[] tags = null)
+        {
+            if (RandomGenerator.ShouldSend(sampleRate))
+            {
+                Send(Metric.GetCommand(metricType, _prefix, name, value, sampleRate, _constantTags, tags));
+                _optionalTelemetry?.OnMetricSent();
+            }
+        }
+
+        public void Send(string command)
+        {
+            _statsBufferize.Send(command);
+        }
+
+        public void Send(Action actionToTime, string statName, double sampleRate = 1.0, string[] tags = null)
+        {
+            var stopwatch = StopwatchFactory.Get();
+
+            try
+            {
+                stopwatch.Start();
+                actionToTime();
+            }
+            finally
+            {
+                stopwatch.Stop();
+                Send(MetricType.Timing, statName, stopwatch.ElapsedMilliseconds(), sampleRate, tags);
+            }
+        }
+
+        private static string EscapeContent(string content)
+        {
+            return content
+                .Replace("\r", string.Empty)
+                .Replace("\n", "\\n");
+        }
+
+        private static string ConcatTags(string[] constantTags, string[] tags)
+        {
+            // avoid dealing with null arrays
+            constantTags = constantTags ?? EmptyStringArray;
+            tags = tags ?? EmptyStringArray;
+
+            if (constantTags.Length == 0 && tags.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            var allTags = constantTags.Concat(tags);
+            string concatenatedTags = string.Join(",", allTags);
+            return $"|#{concatenatedTags}";
+        }
+
+        private static string TruncateOverage(string str, int overage)
+        {
+            return str.Substring(0, str.Length - overage);
+        }
+
+        public abstract class Metric
+        {
+            private static readonly Dictionary<MetricType, string> _commandToUnit = new Dictionary<MetricType, string>
+                                                                {
+                                                                    { MetricType.Counting, "c" },
+                                                                    { MetricType.Timing, "ms" },
+                                                                    { MetricType.Gauge, "g" },
+                                                                    { MetricType.Histogram, "h" },
+                                                                    { MetricType.Distribution, "d" },
+                                                                    { MetricType.Meter, "m" },
+                                                                    { MetricType.Set, "s" },
+                                                                };
+
+            public static string GetCommand<T>(MetricType metricType, string prefix, string name, T value, double sampleRate, string[] constantTags, string[] tags)
+            {
+                string full_name = prefix + name;
+                string unit = _commandToUnit[metricType];
+                var allTags = ConcatTags(constantTags, tags);
+
+                return string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0}:{1}|{2}{3}{4}",
+                    full_name,
+                    value,
+                    unit,
+                    sampleRate == 1.0 ? string.Empty : string.Format(CultureInfo.InvariantCulture, "|@{0}", sampleRate),
+                    allTags);
+            }
+        }
+
+        public class Event
+        {
+            private const int MaxSize = 8 * 1024;
+
+            public static string GetCommand(string title, string text, string alertType, string aggregationKey, string sourceType, int? dateHappened, string priority, string hostname, string[] tags, bool truncateIfTooLong = false)
+            {
+                return GetCommand(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, null, tags, truncateIfTooLong);
+            }
+
+            public static string GetCommand(string title, string text, string alertType, string aggregationKey, string sourceType, int? dateHappened, string priority, string hostname, string[] constantTags, string[] tags, bool truncateIfTooLong = false)
+            {
+                string processedTitle = EscapeContent(title);
+                string processedText = EscapeContent(text);
+                string result = string.Format(CultureInfo.InvariantCulture, "_e{{{0},{1}}}:{2}|{3}", processedTitle.Length.ToString(), processedText.Length.ToString(), processedTitle, processedText);
+                if (dateHappened != null)
+                {
+                    result += string.Format(CultureInfo.InvariantCulture, "|d:{0}", dateHappened);
+                }
+
+                if (hostname != null)
+                {
+                    result += string.Format(CultureInfo.InvariantCulture, "|h:{0}", hostname);
+                }
+
+                if (aggregationKey != null)
+                {
+                    result += string.Format(CultureInfo.InvariantCulture, "|k:{0}", aggregationKey);
+                }
+
+                if (priority != null)
+                {
+                    result += string.Format(CultureInfo.InvariantCulture, "|p:{0}", priority);
+                }
+
+                if (sourceType != null)
+                {
+                    result += string.Format(CultureInfo.InvariantCulture, "|s:{0}", sourceType);
+                }
+
+                if (alertType != null)
+                {
+                    result += string.Format(CultureInfo.InvariantCulture, "|t:{0}", alertType);
+                }
+
+                result += ConcatTags(constantTags, tags);
+
+                if (result.Length > MaxSize)
+                {
+                    if (truncateIfTooLong)
+                    {
+                        var overage = result.Length - MaxSize;
+                        if (title.Length > text.Length)
+                        {
+                            title = TruncateOverage(title, overage);
+                        }
+                        else
+                        {
+                            text = TruncateOverage(text, overage);
+                        }
+
+                        return GetCommand(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, tags, true);
+                    }
+                    else
+                    {
+                        throw new Exception(string.Format("Event {0} payload is too big (more than 8kB)", title));
+                    }
+                }
+
+                return result;
+            }
+        }
+
+        public class ServiceCheck
+        {
+            private const int MaxSize = 8 * 1024;
+
+            public static string GetCommand(string name, int status, int? timestamp, string hostname, string[] tags, string serviceCheckMessage, bool truncateIfTooLong = false)
+            {
+                return GetCommand(name, status, timestamp, hostname, null, tags, serviceCheckMessage, truncateIfTooLong);
+            }
+
+            public static string GetCommand(string name, int status, int? timestamp, string hostname, string[] constantTags, string[] tags, string serviceCheckMessage, bool truncateIfTooLong = false)
+            {
+                string processedName = EscapeName(name);
+                string processedMessage = EscapeMessage(serviceCheckMessage);
+
+                string result = string.Format(CultureInfo.InvariantCulture, "_sc|{0}|{1}", processedName, status);
+
+                if (timestamp != null)
+                {
+                    result += string.Format(CultureInfo.InvariantCulture, "|d:{0}", timestamp);
+                }
+
+                if (hostname != null)
+                {
+                    result += string.Format(CultureInfo.InvariantCulture, "|h:{0}", hostname);
+                }
+
+                result += ConcatTags(constantTags, tags);
+
+                // Note: this must always be appended to the result last.
+                if (processedMessage != null)
+                {
+                    result += string.Format(CultureInfo.InvariantCulture, "|m:{0}", processedMessage);
+                }
+
+                if (result.Length > MaxSize)
+                {
+                    if (!truncateIfTooLong)
+                    {
+                        throw new Exception(string.Format("ServiceCheck {0} payload is too big (more than 8kB)", name));
+                    }
+
+                    var overage = result.Length - MaxSize;
+
+                    if (processedMessage == null || overage > processedMessage.Length)
+                    {
+                        throw new ArgumentException(string.Format("ServiceCheck name is too long to truncate, payload is too big (more than 8Kb) for {0}", name), "name");
+                    }
+
+                    var truncMessage = TruncateOverage(processedMessage, overage);
+                    return GetCommand(name, status, timestamp, hostname, tags, truncMessage, true);
+                }
+
+                return result;
+            }
+
+            // Service check name string, shouldn’t contain any |
+            private static string EscapeName(string name)
+            {
+                name = EscapeContent(name);
+
+                if (name.Contains("|"))
+                {
+                    throw new ArgumentException("Name must not contain any | (pipe) characters", "name");
+                }
+
+                return name;
+            }
+
+            private static string EscapeMessage(string message)
+            {
+                if (!string.IsNullOrEmpty(message))
+                {
+                    return EscapeContent(message).Replace("m:", "m\\:");
+                }
+
+                return message;
+            }
+        }
+    }
+}

--- a/src/StatsdClient/MetricSerializer.cs
+++ b/src/StatsdClient/MetricSerializer.cs
@@ -13,7 +13,7 @@ namespace StatsdClient
 
         internal MetricSerializer(string prefix, string[] constantTags)
         {
-            _prefix = prefix;
+            _prefix = string.IsNullOrEmpty(prefix) ? string.Empty : prefix + ".";
             // copy array to prevent changes, coalesce to empty array
             _constantTags = constantTags?.ToArray() ?? EmptyStringArray;
         }

--- a/src/StatsdClient/MetricSerializer.cs
+++ b/src/StatsdClient/MetricSerializer.cs
@@ -1,0 +1,521 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace StatsdClientTmp
+{
+#pragma warning disable CS1591
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:ElementsMustBeDocumented", Justification = "See ObsoleteAttribute.")]
+    [ObsoleteAttribute("This class will become private in a future release.\n" +
+        "You can use instead `DogStatsdService` or `DogStatsd` which provides automatic metrics" +
+        " buffering with asynchronous calls (metrics are added to a queue and another thread send them).")]
+    public class Statsd : IStatsd
+    {
+        private const string _entityIdInternalTagKey = "dd.internal.entity_id";
+        private static readonly string[] EmptyStringArray = new string[0];
+        private readonly string _prefix;
+        private readonly string[] _constantTags;
+        private readonly Telemetry _optionalTelemetry;
+        private List<string> _commands = new List<string>();
+
+        public Statsd(
+            IStatsdUDP udp,
+            IRandomGenerator randomGenerator,
+            IStopWatchFactory stopwatchFactory,
+            string prefix,
+            string[] constantTags)
+                      : this(udp, randomGenerator, stopwatchFactory, prefix, constantTags, null)
+        {
+        }
+
+        public Statsd(IStatsdUDP udp, IRandomGenerator randomGenerator, IStopWatchFactory stopwatchFactory, string prefix)
+            : this(udp, randomGenerator, stopwatchFactory, prefix, null)
+        {
+        }
+
+        public Statsd(IStatsdUDP udp, IRandomGenerator randomGenerator, IStopWatchFactory stopwatchFactory)
+            : this(udp, randomGenerator, stopwatchFactory, string.Empty)
+        {
+        }
+
+        public Statsd(IStatsdUDP udp, string prefix)
+            : this(udp, new RandomGenerator(), new StopWatchFactory(), prefix)
+        {
+        }
+
+        public Statsd(IStatsdUDP udp)
+            : this(udp, string.Empty)
+        {
+        }
+
+        internal Statsd(
+                    IStatsdUDP udp,
+                    IRandomGenerator randomGenerator,
+                    IStopWatchFactory stopwatchFactory,
+                    string prefix,
+                    string[] constantTags,
+                    Telemetry optionalTelemetry)
+        {
+            StopwatchFactory = stopwatchFactory;
+            Udp = udp;
+            RandomGenerator = randomGenerator;
+            _prefix = prefix;
+            _optionalTelemetry = optionalTelemetry;
+
+            string entityId = Environment.GetEnvironmentVariable(StatsdConfig.DD_ENTITY_ID_ENV_VAR);
+
+            if (string.IsNullOrEmpty(entityId))
+            {
+                // copy array to prevent changes, coalesce to empty array
+                _constantTags = constantTags?.ToArray() ?? EmptyStringArray;
+            }
+            else
+            {
+                var entityIdTags = new[] { $"{_entityIdInternalTagKey}:{entityId}" };
+                _constantTags = constantTags == null ? entityIdTags : constantTags.Concat(entityIdTags).ToArray();
+            }
+        }
+
+        public bool TruncateIfTooLong { get; set; }
+
+        public List<string> Commands
+        {
+            get { return _commands; }
+            private set { _commands = value; }
+        }
+
+        private IStopWatchFactory StopwatchFactory { get; set; }
+
+        private IStatsdUDP Udp { get; set; }
+
+        private IRandomGenerator RandomGenerator { get; set; }
+
+        public void Add<TCommandType, T>(string name, T value, double sampleRate = 1.0, string[] tags = null)
+            where TCommandType : Metric
+        {
+            _commands.Add(Metric.GetCommand<TCommandType, T>(_prefix, name, value, sampleRate, _constantTags, tags));
+            _optionalTelemetry?.OnMetricSent();
+        }
+
+        public void Add(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, string[] tags = null, bool truncateIfTooLong = false)
+        {
+            truncateIfTooLong = truncateIfTooLong || TruncateIfTooLong;
+            _commands.Add(Event.GetCommand(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, _constantTags, tags, truncateIfTooLong));
+            _optionalTelemetry?.OnEventSent();
+        }
+
+        public void Send(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, string[] tags = null, bool truncateIfTooLong = false)
+        {
+            truncateIfTooLong = truncateIfTooLong || TruncateIfTooLong;
+            Send(Event.GetCommand(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, _constantTags, tags, truncateIfTooLong));
+            _optionalTelemetry?.OnEventSent();
+        }
+
+        public Task SendAsync(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, string[] tags = null, bool truncateIfTooLong = false)
+        {
+            truncateIfTooLong = truncateIfTooLong || TruncateIfTooLong;
+            var task = SendAsync(Event.GetCommand(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, _constantTags, tags, truncateIfTooLong));
+            _optionalTelemetry?.OnEventSent();
+            return task;
+        }
+
+        public void Add(string name, int status, int? timestamp = null, string hostname = null, string[] tags = null, string serviceCheckMessage = null, bool truncateIfTooLong = false)
+        {
+            truncateIfTooLong = truncateIfTooLong || TruncateIfTooLong;
+            _commands.Add(ServiceCheck.GetCommand(name, status, timestamp, hostname, _constantTags, tags, serviceCheckMessage, truncateIfTooLong));
+            _optionalTelemetry?.OnServiceCheckSent();
+        }
+
+        public void Send(string name, int status, int? timestamp = null, string hostname = null, string[] tags = null, string serviceCheckMessage = null, bool truncateIfTooLong = false)
+        {
+            truncateIfTooLong = truncateIfTooLong || TruncateIfTooLong;
+            Send(ServiceCheck.GetCommand(name, status, timestamp, hostname, _constantTags, tags, serviceCheckMessage, truncateIfTooLong));
+            _optionalTelemetry?.OnServiceCheckSent();
+        }
+
+        public Task SendAsync(string name, int status, int? timestamp = null, string hostname = null, string[] tags = null, string serviceCheckMessage = null, bool truncateIfTooLong = false)
+        {
+            truncateIfTooLong = truncateIfTooLong || TruncateIfTooLong;
+            var task = SendAsync(ServiceCheck.GetCommand(name, status, timestamp, hostname, _constantTags, tags, serviceCheckMessage, truncateIfTooLong));
+            _optionalTelemetry?.OnServiceCheckSent();
+            return task;
+        }
+
+        public void Send<TCommandType, T>(string name, T value, double sampleRate = 1.0, string[] tags = null)
+            where TCommandType : Metric
+        {
+            if (RandomGenerator.ShouldSend(sampleRate))
+            {
+                Send(Metric.GetCommand<TCommandType, T>(_prefix, name, value, sampleRate, _constantTags, tags));
+                _optionalTelemetry?.OnMetricSent();
+            }
+        }
+
+        public Task SendAsync<TCommandType, T>(string name, T value, double sampleRate = 1.0, string[] tags = null)
+            where TCommandType : Metric
+        {
+            if (RandomGenerator.ShouldSend(sampleRate))
+            {
+                var task = SendAsync(Metric.GetCommand<TCommandType, T>(_prefix, name, value, sampleRate, _constantTags, tags));
+                _optionalTelemetry?.OnMetricSent();
+                return task;
+            }
+
+            return Task.FromResult((object)null);
+        }
+
+        public void Send(string command)
+        {
+            try
+            {
+                // clear buffer (keep existing behavior)
+                if (Commands.Count > 0)
+                {
+                    Commands = new List<string>();
+                }
+
+                Udp.Send(command);
+            }
+            catch (Exception e)
+            {
+                Debug.WriteLine(e.Message);
+            }
+        }
+
+        public async Task SendAsync(string command)
+        {
+            try
+            {
+                // clear buffer (keep existing behavior)
+                if (Commands.Count > 0)
+                {
+                    Commands = new List<string>();
+                }
+
+                await Udp.SendAsync(command).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                Debug.WriteLine(e.Message);
+            }
+        }
+
+        public void Send()
+        {
+            int count = Commands.Count;
+            if (count < 1)
+            {
+                return;
+            }
+
+            Send(count == 1 ? Commands[0] : string.Join("\n", Commands.ToArray()));
+        }
+
+        public Task SendAsync()
+        {
+            int count = Commands.Count;
+            if (count < 1)
+            {
+                return Task.FromResult((object)null);
+            }
+
+            return SendAsync(count == 1 ? Commands[0] : string.Join("\n", Commands.ToArray()));
+        }
+
+        public void Add(Action actionToTime, string statName, double sampleRate = 1.0, string[] tags = null)
+        {
+            var stopwatch = StopwatchFactory.Get();
+
+            try
+            {
+                stopwatch.Start();
+                actionToTime();
+            }
+            finally
+            {
+                stopwatch.Stop();
+                Add<Timing, int>(statName, stopwatch.ElapsedMilliseconds(), sampleRate, tags);
+            }
+        }
+
+        public void Send(Action actionToTime, string statName, double sampleRate = 1.0, string[] tags = null)
+        {
+            var stopwatch = StopwatchFactory.Get();
+
+            try
+            {
+                stopwatch.Start();
+                actionToTime();
+            }
+            finally
+            {
+                stopwatch.Stop();
+                Send<Timing, int>(statName, stopwatch.ElapsedMilliseconds(), sampleRate, tags);
+            }
+        }
+
+        public async Task SendAsync(Action actionToTime, string statName, double sampleRate = 1.0, string[] tags = null)
+        {
+            var stopwatch = StopwatchFactory.Get();
+
+            try
+            {
+                stopwatch.Start();
+                actionToTime();
+            }
+            finally
+            {
+                stopwatch.Stop();
+                await SendAsync<Timing, int>(statName, stopwatch.ElapsedMilliseconds(), sampleRate, tags).ConfigureAwait(false);
+            }
+        }
+
+        private static string EscapeContent(string content)
+        {
+            return content
+                .Replace("\r", string.Empty)
+                .Replace("\n", "\\n");
+        }
+
+        private static string ConcatTags(string[] constantTags, string[] tags)
+        {
+            // avoid dealing with null arrays
+            constantTags = constantTags ?? EmptyStringArray;
+            tags = tags ?? EmptyStringArray;
+
+            if (constantTags.Length == 0 && tags.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            var allTags = constantTags.Concat(tags);
+            string concatenatedTags = string.Join(",", allTags);
+            return $"|#{concatenatedTags}";
+        }
+
+        private static string TruncateOverage(string str, int overage)
+        {
+            return str.Substring(0, str.Length - overage);
+        }
+
+        public class Counting : Metric
+        {
+        }
+
+        public class Timing : Metric
+        {
+        }
+
+        public class Gauge : Metric
+        {
+        }
+
+        public class Histogram : Metric
+        {
+        }
+
+        public class Distribution : Metric
+        {
+        }
+
+        public class Meter : Metric
+        {
+        }
+
+        public class Set : Metric
+        {
+        }
+
+        public abstract class Metric : ICommandType
+        {
+            private static readonly Dictionary<Type, string> _commandToUnit = new Dictionary<Type, string>
+                                                                {
+                                                                    { typeof(Counting), "c" },
+                                                                    { typeof(Timing), "ms" },
+                                                                    { typeof(Gauge), "g" },
+                                                                    { typeof(Histogram), "h" },
+                                                                    { typeof(Distribution), "d" },
+                                                                    { typeof(Meter), "m" },
+                                                                    { typeof(Set), "s" },
+                                                                };
+
+            public static string GetCommand<TCommandType, T>(string prefix, string name, T value, double sampleRate, string[] tags)
+                where TCommandType : Metric
+            {
+                return GetCommand<TCommandType, T>(prefix, name, value, sampleRate, null, tags);
+            }
+
+            public static string GetCommand<TCommandType, T>(string prefix, string name, T value, double sampleRate, string[] constantTags, string[] tags)
+                where TCommandType : Metric
+            {
+                string full_name = prefix + name;
+                string unit = _commandToUnit[typeof(TCommandType)];
+                var allTags = ConcatTags(constantTags, tags);
+
+                return string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0}:{1}|{2}{3}{4}",
+                    full_name,
+                    value,
+                    unit,
+                    sampleRate == 1.0 ? string.Empty : string.Format(CultureInfo.InvariantCulture, "|@{0}", sampleRate),
+                    allTags);
+            }
+        }
+
+        public class Event : ICommandType
+        {
+            private const int MaxSize = 8 * 1024;
+
+            public static string GetCommand(string title, string text, string alertType, string aggregationKey, string sourceType, int? dateHappened, string priority, string hostname, string[] tags, bool truncateIfTooLong = false)
+            {
+                return GetCommand(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, null, tags, truncateIfTooLong);
+            }
+
+            public static string GetCommand(string title, string text, string alertType, string aggregationKey, string sourceType, int? dateHappened, string priority, string hostname, string[] constantTags, string[] tags, bool truncateIfTooLong = false)
+            {
+                string processedTitle = EscapeContent(title);
+                string processedText = EscapeContent(text);
+                string result = string.Format(CultureInfo.InvariantCulture, "_e{{{0},{1}}}:{2}|{3}", processedTitle.Length.ToString(), processedText.Length.ToString(), processedTitle, processedText);
+                if (dateHappened != null)
+                {
+                    result += string.Format(CultureInfo.InvariantCulture, "|d:{0}", dateHappened);
+                }
+
+                if (hostname != null)
+                {
+                    result += string.Format(CultureInfo.InvariantCulture, "|h:{0}", hostname);
+                }
+
+                if (aggregationKey != null)
+                {
+                    result += string.Format(CultureInfo.InvariantCulture, "|k:{0}", aggregationKey);
+                }
+
+                if (priority != null)
+                {
+                    result += string.Format(CultureInfo.InvariantCulture, "|p:{0}", priority);
+                }
+
+                if (sourceType != null)
+                {
+                    result += string.Format(CultureInfo.InvariantCulture, "|s:{0}", sourceType);
+                }
+
+                if (alertType != null)
+                {
+                    result += string.Format(CultureInfo.InvariantCulture, "|t:{0}", alertType);
+                }
+
+                result += ConcatTags(constantTags, tags);
+
+                if (result.Length > MaxSize)
+                {
+                    if (truncateIfTooLong)
+                    {
+                        var overage = result.Length - MaxSize;
+                        if (title.Length > text.Length)
+                        {
+                            title = TruncateOverage(title, overage);
+                        }
+                        else
+                        {
+                            text = TruncateOverage(text, overage);
+                        }
+
+                        return GetCommand(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, tags, true);
+                    }
+                    else
+                    {
+                        throw new Exception(string.Format("Event {0} payload is too big (more than 8kB)", title));
+                    }
+                }
+
+                return result;
+            }
+        }
+
+        public class ServiceCheck : ICommandType
+        {
+            private const int MaxSize = 8 * 1024;
+
+            public static string GetCommand(string name, int status, int? timestamp, string hostname, string[] tags, string serviceCheckMessage, bool truncateIfTooLong = false)
+            {
+                return GetCommand(name, status, timestamp, hostname, null, tags, serviceCheckMessage, truncateIfTooLong);
+            }
+
+            public static string GetCommand(string name, int status, int? timestamp, string hostname, string[] constantTags, string[] tags, string serviceCheckMessage, bool truncateIfTooLong = false)
+            {
+                string processedName = EscapeName(name);
+                string processedMessage = EscapeMessage(serviceCheckMessage);
+
+                string result = string.Format(CultureInfo.InvariantCulture, "_sc|{0}|{1}", processedName, status);
+
+                if (timestamp != null)
+                {
+                    result += string.Format(CultureInfo.InvariantCulture, "|d:{0}", timestamp);
+                }
+
+                if (hostname != null)
+                {
+                    result += string.Format(CultureInfo.InvariantCulture, "|h:{0}", hostname);
+                }
+
+                result += ConcatTags(constantTags, tags);
+
+                // Note: this must always be appended to the result last.
+                if (processedMessage != null)
+                {
+                    result += string.Format(CultureInfo.InvariantCulture, "|m:{0}", processedMessage);
+                }
+
+                if (result.Length > MaxSize)
+                {
+                    if (!truncateIfTooLong)
+                    {
+                        throw new Exception(string.Format("ServiceCheck {0} payload is too big (more than 8kB)", name));
+                    }
+
+                    var overage = result.Length - MaxSize;
+
+                    if (processedMessage == null || overage > processedMessage.Length)
+                    {
+                        throw new ArgumentException(string.Format("ServiceCheck name is too long to truncate, payload is too big (more than 8Kb) for {0}", name), "name");
+                    }
+
+                    var truncMessage = TruncateOverage(processedMessage, overage);
+                    return GetCommand(name, status, timestamp, hostname, tags, truncMessage, true);
+                }
+
+                return result;
+            }
+
+            // Service check name string, shouldn’t contain any |
+            private static string EscapeName(string name)
+            {
+                name = EscapeContent(name);
+
+                if (name.Contains("|"))
+                {
+                    throw new ArgumentException("Name must not contain any | (pipe) characters", "name");
+                }
+
+                return name;
+            }
+
+            private static string EscapeMessage(string message)
+            {
+                if (!string.IsNullOrEmpty(message))
+                {
+                    return EscapeContent(message).Replace("m:", "m\\:");
+                }
+
+                return message;
+            }
+        }
+    }
+}

--- a/src/StatsdClient/MetricSerializer.cs
+++ b/src/StatsdClient/MetricSerializer.cs
@@ -65,7 +65,7 @@ namespace StatsdClient
         {
             private static readonly Dictionary<MetricType, string> _commandToUnit = new Dictionary<MetricType, string>
                                                                 {
-                                                                    { MetricType.Counting, "c" },
+                                                                    { MetricType.Count, "c" },
                                                                     { MetricType.Timing, "ms" },
                                                                     { MetricType.Gauge, "g" },
                                                                     { MetricType.Histogram, "h" },

--- a/src/StatsdClient/MetricType.cs
+++ b/src/StatsdClient/MetricType.cs
@@ -1,0 +1,13 @@
+namespace StatsdClient
+{
+    internal enum MetricType
+    {
+        Counting,
+        Timing,
+        Gauge,
+        Histogram,
+        Distribution,
+        Meter,
+        Set,
+    }
+}

--- a/src/StatsdClient/MetricType.cs
+++ b/src/StatsdClient/MetricType.cs
@@ -2,7 +2,7 @@ namespace StatsdClient
 {
     internal enum MetricType
     {
-        Counting,
+        Count,
         Timing,
         Gauge,
         Histogram,

--- a/src/StatsdClient/MetricsSender.cs
+++ b/src/StatsdClient/MetricsSender.cs
@@ -29,32 +29,27 @@ namespace StatsdClient
 
         private IRandomGenerator RandomGenerator { get; set; }
 
-        public void Send(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, string[] tags = null, bool truncateIfTooLong = false)
+        public void SendEvent(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, string[] tags = null, bool truncateIfTooLong = false)
         {
             truncateIfTooLong = truncateIfTooLong || TruncateIfTooLong;
-            Send(_metricSerializer.SerializeEvent(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, tags, truncateIfTooLong));
+            _statsBufferize.Send(_metricSerializer.SerializeEvent(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, tags, truncateIfTooLong));
             _optionalTelemetry?.OnEventSent();
         }
 
-        public void Send(string name, int status, int? timestamp = null, string hostname = null, string[] tags = null, string serviceCheckMessage = null, bool truncateIfTooLong = false)
+        public void SendServiceCheck(string name, int status, int? timestamp = null, string hostname = null, string[] tags = null, string serviceCheckMessage = null, bool truncateIfTooLong = false)
         {
             truncateIfTooLong = truncateIfTooLong || TruncateIfTooLong;
-            Send(_metricSerializer.SerializeServiceCheck(name, status, timestamp, hostname, tags, serviceCheckMessage, truncateIfTooLong));
+            _statsBufferize.Send(_metricSerializer.SerializeServiceCheck(name, status, timestamp, hostname, tags, serviceCheckMessage, truncateIfTooLong));
             _optionalTelemetry?.OnServiceCheckSent();
         }
 
-        public void Send<T>(MetricType metricType, string name, T value, double sampleRate = 1.0, string[] tags = null)
+        public void SendMetric<T>(MetricType metricType, string name, T value, double sampleRate = 1.0, string[] tags = null)
         {
             if (RandomGenerator.ShouldSend(sampleRate))
             {
-                Send(_metricSerializer.SerializeMetric(metricType, name, value, sampleRate, tags));
+                _statsBufferize.Send(_metricSerializer.SerializeMetric(metricType, name, value, sampleRate, tags));
                 _optionalTelemetry?.OnMetricSent();
             }
-        }
-
-        public void Send(string command)
-        {
-            _statsBufferize.Send(command);
         }
 
         public void Send(Action actionToTime, string statName, double sampleRate = 1.0, string[] tags = null)
@@ -69,7 +64,7 @@ namespace StatsdClient
             finally
             {
                 stopwatch.Stop();
-                Send(MetricType.Timing, statName, stopwatch.ElapsedMilliseconds(), sampleRate, tags);
+                SendMetric(MetricType.Timing, statName, stopwatch.ElapsedMilliseconds(), sampleRate, tags);
             }
         }
     }

--- a/src/StatsdClient/MetricsSender.cs
+++ b/src/StatsdClient/MetricsSender.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using StatsdClient.Bufferize;
 
 namespace StatsdClient
 {
@@ -14,9 +15,10 @@ namespace StatsdClient
         private readonly string[] _constantTags;
         private readonly Telemetry _optionalTelemetry;
         private List<string> _commands = new List<string>();
+        private readonly StatsBufferize _statsBufferize;
 
         internal MetricsSender(
-                    IStatsdUDP udp,
+                    StatsBufferize statsBufferize,
                     IRandomGenerator randomGenerator,
                     IStopWatchFactory stopwatchFactory,
                     string prefix,
@@ -24,7 +26,7 @@ namespace StatsdClient
                     Telemetry optionalTelemetry)
         {
             StopwatchFactory = stopwatchFactory;
-            Udp = udp;
+            _statsBufferize = statsBufferize;
             RandomGenerator = randomGenerator;
             _prefix = prefix;
             _optionalTelemetry = optionalTelemetry;
@@ -52,8 +54,6 @@ namespace StatsdClient
         }
 
         private IStopWatchFactory StopwatchFactory { get; set; }
-
-        private IStatsdUDP Udp { get; set; }
 
         private IRandomGenerator RandomGenerator { get; set; }
 
@@ -91,7 +91,7 @@ namespace StatsdClient
                     Commands = new List<string>();
                 }
 
-                Udp.Send(command);
+                 _statsBufferize.Send(command);
             }
             catch (Exception e)
             {

--- a/src/StatsdClient/MetricsSender.cs
+++ b/src/StatsdClient/MetricsSender.cs
@@ -14,7 +14,6 @@ namespace StatsdClient
         private readonly string _prefix;
         private readonly string[] _constantTags;
         private readonly Telemetry _optionalTelemetry;
-        private List<string> _commands = new List<string>();
         private readonly StatsBufferize _statsBufferize;
 
         internal MetricsSender(
@@ -47,12 +46,6 @@ namespace StatsdClient
 
         public bool TruncateIfTooLong { get; set; }
 
-        public List<string> Commands
-        {
-            get { return _commands; }
-            private set { _commands = value; }
-        }
-
         private IStopWatchFactory StopwatchFactory { get; set; }
 
         private IRandomGenerator RandomGenerator { get; set; }
@@ -83,31 +76,7 @@ namespace StatsdClient
 
         public void Send(string command)
         {
-            try
-            {
-                // clear buffer (keep existing behavior)
-                if (Commands.Count > 0)
-                {
-                    Commands = new List<string>();
-                }
-
-                 _statsBufferize.Send(command);
-            }
-            catch (Exception e)
-            {
-                Debug.WriteLine(e.Message);
-            }
-        }
-
-        public void Send()
-        {
-            int count = Commands.Count;
-            if (count < 1)
-            {
-                return;
-            }
-
-            Send(count == 1 ? Commands[0] : string.Join("\n", Commands.ToArray()));
+            _statsBufferize.Send(command);
         }
 
         public void Send(Action actionToTime, string statName, double sampleRate = 1.0, string[] tags = null)
@@ -194,12 +163,6 @@ namespace StatsdClient
                                                                     { typeof(Meter), "m" },
                                                                     { typeof(Set), "s" },
                                                                 };
-
-            public static string GetCommand<TCommandType, T>(string prefix, string name, T value, double sampleRate, string[] tags)
-                where TCommandType : Metric
-            {
-                return GetCommand<TCommandType, T>(prefix, name, value, sampleRate, null, tags);
-            }
 
             public static string GetCommand<TCommandType, T>(string prefix, string name, T value, double sampleRate, string[] constantTags, string[] tags)
                 where TCommandType : Metric

--- a/src/StatsdClient/MetricsSender.cs
+++ b/src/StatsdClient/MetricsSender.cs
@@ -9,7 +9,6 @@ namespace StatsdClient
 {
     internal class MetricsSender
     {
-        private const string _entityIdInternalTagKey = "dd.internal.entity_id";
         private static readonly string[] EmptyStringArray = new string[0];
         private readonly string _prefix;
         private readonly string[] _constantTags;
@@ -30,18 +29,8 @@ namespace StatsdClient
             _prefix = prefix;
             _optionalTelemetry = optionalTelemetry;
 
-            string entityId = Environment.GetEnvironmentVariable(StatsdConfig.DD_ENTITY_ID_ENV_VAR);
-
-            if (string.IsNullOrEmpty(entityId))
-            {
-                // copy array to prevent changes, coalesce to empty array
-                _constantTags = constantTags?.ToArray() ?? EmptyStringArray;
-            }
-            else
-            {
-                var entityIdTags = new[] { $"{_entityIdInternalTagKey}:{entityId}" };
-                _constantTags = constantTags == null ? entityIdTags : constantTags.Concat(entityIdTags).ToArray();
-            }
+            // copy array to prevent changes, coalesce to empty array
+            _constantTags = constantTags?.ToArray() ?? EmptyStringArray;
         }
 
         public enum MetricType

--- a/src/StatsdClient/MetricsSender.cs
+++ b/src/StatsdClient/MetricsSender.cs
@@ -1,47 +1,26 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
-using System.Linq;
 using StatsdClient.Bufferize;
 
 namespace StatsdClient
 {
     internal class MetricsSender
     {
-        private static readonly string[] EmptyStringArray = new string[0];
-        private readonly string _prefix;
-        private readonly string[] _constantTags;
         private readonly Telemetry _optionalTelemetry;
         private readonly StatsBufferize _statsBufferize;
+        private readonly MetricSerializer _metricSerializer;
 
         internal MetricsSender(
                     StatsBufferize statsBufferize,
                     IRandomGenerator randomGenerator,
                     IStopWatchFactory stopwatchFactory,
-                    string prefix,
-                    string[] constantTags,
+                    MetricSerializer metricSerializer,
                     Telemetry optionalTelemetry)
         {
             StopwatchFactory = stopwatchFactory;
             _statsBufferize = statsBufferize;
             RandomGenerator = randomGenerator;
-            _prefix = prefix;
             _optionalTelemetry = optionalTelemetry;
-
-            // copy array to prevent changes, coalesce to empty array
-            _constantTags = constantTags?.ToArray() ?? EmptyStringArray;
-        }
-
-        public enum MetricType
-        {
-            Counting,
-            Timing,
-            Gauge,
-            Histogram,
-            Distribution,
-            Meter,
-            Set,
+            _metricSerializer = metricSerializer;
         }
 
         public bool TruncateIfTooLong { get; set; }
@@ -53,14 +32,14 @@ namespace StatsdClient
         public void Send(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, string[] tags = null, bool truncateIfTooLong = false)
         {
             truncateIfTooLong = truncateIfTooLong || TruncateIfTooLong;
-            Send(Event.GetCommand(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, _constantTags, tags, truncateIfTooLong));
+            Send(_metricSerializer.SerializeEvent(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, tags, truncateIfTooLong));
             _optionalTelemetry?.OnEventSent();
         }
 
         public void Send(string name, int status, int? timestamp = null, string hostname = null, string[] tags = null, string serviceCheckMessage = null, bool truncateIfTooLong = false)
         {
             truncateIfTooLong = truncateIfTooLong || TruncateIfTooLong;
-            Send(ServiceCheck.GetCommand(name, status, timestamp, hostname, _constantTags, tags, serviceCheckMessage, truncateIfTooLong));
+            Send(_metricSerializer.SerializeServiceCheck(name, status, timestamp, hostname, tags, serviceCheckMessage, truncateIfTooLong));
             _optionalTelemetry?.OnServiceCheckSent();
         }
 
@@ -68,7 +47,7 @@ namespace StatsdClient
         {
             if (RandomGenerator.ShouldSend(sampleRate))
             {
-                Send(Metric.GetCommand(metricType, _prefix, name, value, sampleRate, _constantTags, tags));
+                Send(_metricSerializer.SerializeMetric(metricType, name, value, sampleRate, tags));
                 _optionalTelemetry?.OnMetricSent();
             }
         }
@@ -91,215 +70,6 @@ namespace StatsdClient
             {
                 stopwatch.Stop();
                 Send(MetricType.Timing, statName, stopwatch.ElapsedMilliseconds(), sampleRate, tags);
-            }
-        }
-
-        private static string EscapeContent(string content)
-        {
-            return content
-                .Replace("\r", string.Empty)
-                .Replace("\n", "\\n");
-        }
-
-        private static string ConcatTags(string[] constantTags, string[] tags)
-        {
-            // avoid dealing with null arrays
-            constantTags = constantTags ?? EmptyStringArray;
-            tags = tags ?? EmptyStringArray;
-
-            if (constantTags.Length == 0 && tags.Length == 0)
-            {
-                return string.Empty;
-            }
-
-            var allTags = constantTags.Concat(tags);
-            string concatenatedTags = string.Join(",", allTags);
-            return $"|#{concatenatedTags}";
-        }
-
-        private static string TruncateOverage(string str, int overage)
-        {
-            return str.Substring(0, str.Length - overage);
-        }
-
-        public abstract class Metric
-        {
-            private static readonly Dictionary<MetricType, string> _commandToUnit = new Dictionary<MetricType, string>
-                                                                {
-                                                                    { MetricType.Counting, "c" },
-                                                                    { MetricType.Timing, "ms" },
-                                                                    { MetricType.Gauge, "g" },
-                                                                    { MetricType.Histogram, "h" },
-                                                                    { MetricType.Distribution, "d" },
-                                                                    { MetricType.Meter, "m" },
-                                                                    { MetricType.Set, "s" },
-                                                                };
-
-            public static string GetCommand<T>(MetricType metricType, string prefix, string name, T value, double sampleRate, string[] constantTags, string[] tags)
-            {
-                string full_name = prefix + name;
-                string unit = _commandToUnit[metricType];
-                var allTags = ConcatTags(constantTags, tags);
-
-                return string.Format(
-                    CultureInfo.InvariantCulture,
-                    "{0}:{1}|{2}{3}{4}",
-                    full_name,
-                    value,
-                    unit,
-                    sampleRate == 1.0 ? string.Empty : string.Format(CultureInfo.InvariantCulture, "|@{0}", sampleRate),
-                    allTags);
-            }
-        }
-
-        public class Event
-        {
-            private const int MaxSize = 8 * 1024;
-
-            public static string GetCommand(string title, string text, string alertType, string aggregationKey, string sourceType, int? dateHappened, string priority, string hostname, string[] tags, bool truncateIfTooLong = false)
-            {
-                return GetCommand(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, null, tags, truncateIfTooLong);
-            }
-
-            public static string GetCommand(string title, string text, string alertType, string aggregationKey, string sourceType, int? dateHappened, string priority, string hostname, string[] constantTags, string[] tags, bool truncateIfTooLong = false)
-            {
-                string processedTitle = EscapeContent(title);
-                string processedText = EscapeContent(text);
-                string result = string.Format(CultureInfo.InvariantCulture, "_e{{{0},{1}}}:{2}|{3}", processedTitle.Length.ToString(), processedText.Length.ToString(), processedTitle, processedText);
-                if (dateHappened != null)
-                {
-                    result += string.Format(CultureInfo.InvariantCulture, "|d:{0}", dateHappened);
-                }
-
-                if (hostname != null)
-                {
-                    result += string.Format(CultureInfo.InvariantCulture, "|h:{0}", hostname);
-                }
-
-                if (aggregationKey != null)
-                {
-                    result += string.Format(CultureInfo.InvariantCulture, "|k:{0}", aggregationKey);
-                }
-
-                if (priority != null)
-                {
-                    result += string.Format(CultureInfo.InvariantCulture, "|p:{0}", priority);
-                }
-
-                if (sourceType != null)
-                {
-                    result += string.Format(CultureInfo.InvariantCulture, "|s:{0}", sourceType);
-                }
-
-                if (alertType != null)
-                {
-                    result += string.Format(CultureInfo.InvariantCulture, "|t:{0}", alertType);
-                }
-
-                result += ConcatTags(constantTags, tags);
-
-                if (result.Length > MaxSize)
-                {
-                    if (truncateIfTooLong)
-                    {
-                        var overage = result.Length - MaxSize;
-                        if (title.Length > text.Length)
-                        {
-                            title = TruncateOverage(title, overage);
-                        }
-                        else
-                        {
-                            text = TruncateOverage(text, overage);
-                        }
-
-                        return GetCommand(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, tags, true);
-                    }
-                    else
-                    {
-                        throw new Exception(string.Format("Event {0} payload is too big (more than 8kB)", title));
-                    }
-                }
-
-                return result;
-            }
-        }
-
-        public class ServiceCheck
-        {
-            private const int MaxSize = 8 * 1024;
-
-            public static string GetCommand(string name, int status, int? timestamp, string hostname, string[] tags, string serviceCheckMessage, bool truncateIfTooLong = false)
-            {
-                return GetCommand(name, status, timestamp, hostname, null, tags, serviceCheckMessage, truncateIfTooLong);
-            }
-
-            public static string GetCommand(string name, int status, int? timestamp, string hostname, string[] constantTags, string[] tags, string serviceCheckMessage, bool truncateIfTooLong = false)
-            {
-                string processedName = EscapeName(name);
-                string processedMessage = EscapeMessage(serviceCheckMessage);
-
-                string result = string.Format(CultureInfo.InvariantCulture, "_sc|{0}|{1}", processedName, status);
-
-                if (timestamp != null)
-                {
-                    result += string.Format(CultureInfo.InvariantCulture, "|d:{0}", timestamp);
-                }
-
-                if (hostname != null)
-                {
-                    result += string.Format(CultureInfo.InvariantCulture, "|h:{0}", hostname);
-                }
-
-                result += ConcatTags(constantTags, tags);
-
-                // Note: this must always be appended to the result last.
-                if (processedMessage != null)
-                {
-                    result += string.Format(CultureInfo.InvariantCulture, "|m:{0}", processedMessage);
-                }
-
-                if (result.Length > MaxSize)
-                {
-                    if (!truncateIfTooLong)
-                    {
-                        throw new Exception(string.Format("ServiceCheck {0} payload is too big (more than 8kB)", name));
-                    }
-
-                    var overage = result.Length - MaxSize;
-
-                    if (processedMessage == null || overage > processedMessage.Length)
-                    {
-                        throw new ArgumentException(string.Format("ServiceCheck name is too long to truncate, payload is too big (more than 8Kb) for {0}", name), "name");
-                    }
-
-                    var truncMessage = TruncateOverage(processedMessage, overage);
-                    return GetCommand(name, status, timestamp, hostname, tags, truncMessage, true);
-                }
-
-                return result;
-            }
-
-            // Service check name string, shouldn’t contain any |
-            private static string EscapeName(string name)
-            {
-                name = EscapeContent(name);
-
-                if (name.Contains("|"))
-                {
-                    throw new ArgumentException("Name must not contain any | (pipe) characters", "name");
-                }
-
-                return name;
-            }
-
-            private static string EscapeMessage(string message)
-            {
-                if (!string.IsNullOrEmpty(message))
-                {
-                    return EscapeContent(message).Replace("m:", "m\\:");
-                }
-
-                return message;
             }
         }
     }

--- a/src/StatsdClient/StatsdBuilder.cs
+++ b/src/StatsdClient/StatsdBuilder.cs
@@ -51,8 +51,8 @@ namespace StatsdClient
                 new RandomGenerator(),
                 new StopWatchFactory(),
                 metricSerializer,
-                telemetry);
-            metricsSender.TruncateIfTooLong = config.StatsdTruncateIfTooLong;
+                telemetry,
+                config.StatsdTruncateIfTooLong);
             return new StatsdData(metricsSender, statsBufferize, statsSender, telemetry);
         }
 

--- a/src/StatsdClient/StatsdBuilder.cs
+++ b/src/StatsdClient/StatsdBuilder.cs
@@ -49,7 +49,7 @@ namespace StatsdClient
                 new RandomGenerator(),
                 new StopWatchFactory(),
                 string.Empty,
-                config.ConstantTags,
+                globalTags,
                 telemetry);
             metricsSender.TruncateIfTooLong = config.StatsdTruncateIfTooLong;
             return new StatsdData(metricsSender, statsBufferize, statsSender, telemetry);

--- a/src/StatsdClient/StatsdBuilder.cs
+++ b/src/StatsdClient/StatsdBuilder.cs
@@ -44,15 +44,15 @@ namespace StatsdClient
                 statsSenderData.Sender,
                 statsSenderData.BufferCapacity,
                 config.Advanced);
-            var statsD = new Statsd(
+            var metricsSender = new MetricsSender(
                 statsBufferize,
                 new RandomGenerator(),
                 new StopWatchFactory(),
                 string.Empty,
                 config.ConstantTags,
                 telemetry);
-            statsD.TruncateIfTooLong = config.StatsdTruncateIfTooLong;
-            return new StatsdData(statsD, statsBufferize, statsSender, telemetry);
+            metricsSender.TruncateIfTooLong = config.StatsdTruncateIfTooLong;
+            return new StatsdData(metricsSender, statsBufferize, statsSender, telemetry);
         }
 
         private static int GetPort(StatsdConfig config)

--- a/src/StatsdClient/StatsdBuilder.cs
+++ b/src/StatsdClient/StatsdBuilder.cs
@@ -45,7 +45,7 @@ namespace StatsdClient
                 statsSenderData.BufferCapacity,
                 config.Advanced);
 
-            var metricSerializer = new MetricSerializer(string.Empty, globalTags);
+            var metricSerializer = new MetricSerializer(config.Prefix, globalTags);
             var metricsSender = new MetricsSender(
                 statsBufferize,
                 new RandomGenerator(),

--- a/src/StatsdClient/StatsdBuilder.cs
+++ b/src/StatsdClient/StatsdBuilder.cs
@@ -44,12 +44,13 @@ namespace StatsdClient
                 statsSenderData.Sender,
                 statsSenderData.BufferCapacity,
                 config.Advanced);
+
+            var metricSerializer = new MetricSerializer(string.Empty, globalTags);
             var metricsSender = new MetricsSender(
                 statsBufferize,
                 new RandomGenerator(),
                 new StopWatchFactory(),
-                string.Empty,
-                globalTags,
+                metricSerializer,
                 telemetry);
             metricsSender.TruncateIfTooLong = config.StatsdTruncateIfTooLong;
             return new StatsdData(metricsSender, statsBufferize, statsSender, telemetry);

--- a/src/StatsdClient/StatsdData.cs
+++ b/src/StatsdClient/StatsdData.cs
@@ -9,18 +9,18 @@ namespace StatsdClient
         private StatsBufferize _statsBufferize;
 
         public StatsdData(
-            Statsd statsd,
+            MetricsSender metricsSender,
             StatsBufferize statsBufferize,
             StatsSender statsSender,
             Telemetry telemetry)
         {
-            Statsd = statsd;
+            MetricsSender = metricsSender;
             Telemetry = telemetry;
             _statsBufferize = statsBufferize;
             _statsSender = statsSender;
         }
 
-        public Statsd Statsd { get; private set; }
+        public MetricsSender MetricsSender { get; private set; }
 
         public Telemetry Telemetry { get; private set; }
 
@@ -38,7 +38,7 @@ namespace StatsdClient
             _statsSender?.Dispose();
             _statsSender = null;
 
-            Statsd = null;
+            MetricsSender = null;
         }
     }
 }


### PR DESCRIPTION
This PR replaces `Statsd` class by several smaller components to make code easier to maintain. 
`Statsd` is now unused but it is kept for backward compatibility reasons.

For reviewer:
  - Reviewing commit by commit is recommended.
  - The class `MetricSerializer` contains a lot of code from the class `Statsd` that could be improved, but `MetricSerializer` is going to be refactored in a later PR.
