### PR TITLE
Handle disconnection / reconnection

### DIFF
--- a/src/StatsdClient/StatsSender.cs
+++ b/src/StatsdClient/StatsSender.cs
@@ -11,6 +11,7 @@ namespace StatsdClient
         private static readonly TimeSpan NoBufferSpaceAvailableWait = TimeSpan.FromMilliseconds(10);
         private readonly Socket _socket;
         private readonly int _noBufferSpaceAvailableRetryCount;
+        private readonly EndPoint _endPoint;
 
         private StatsSender(
             StatsSenderTransportType transport,
@@ -20,6 +21,7 @@ namespace StatsdClient
             TimeSpan? bufferFullBlockDuration)
         {
             TransportType = transport;
+            _endPoint = endPoint;
             if (bufferFullBlockDuration.HasValue)
             {
                 _noBufferSpaceAvailableRetryCount = (int)(bufferFullBlockDuration.Value.TotalMilliseconds
@@ -52,8 +54,6 @@ namespace StatsdClient
             {
                 // It is not supported on Windows for Dgram with UDP.
             }
-
-            _socket.Connect(endPoint);
         }
 
         public StatsSenderTransportType TransportType { get; }
@@ -90,7 +90,7 @@ namespace StatsdClient
             {
                 try
                 {
-                    _socket.Send(buffer, 0, length, SocketFlags.None);
+                    _socket.SendTo(buffer, 0, length, SocketFlags.None, _endPoint);
                     return true;
                 }
                 catch (SocketException e) when (e.SocketErrorCode == SocketError.NoBufferSpaceAvailable)

--- a/tests/StatsdClient.Tests/DogStatsdServiceReconnectionTests.cs
+++ b/tests/StatsdClient.Tests/DogStatsdServiceReconnectionTests.cs
@@ -20,6 +20,7 @@ namespace Tests
             });
         }
 
+#if !OS_WINDOWS
         [Test]
         public void UDSReconnection()
         {
@@ -31,6 +32,7 @@ namespace Tests
                 });
             }
         }
+#endif
 
         private static void CheckReconnection(StatsdConfig config)
         {

--- a/tests/StatsdClient.Tests/DogStatsdServiceReconnectionTests.cs
+++ b/tests/StatsdClient.Tests/DogStatsdServiceReconnectionTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using StatsdClient;
+using Tests.Utils;
+
+namespace Tests
+{
+    [TestFixture]
+    public class DogStatsdServiceReconnectionTests
+    {
+        [Test]
+        public void UDPReconnection()
+        {
+            CheckReconnection(new StatsdConfig
+            {
+                StatsdServerName = "127.0.0.1",
+                StatsdPort = 1234,
+            });
+        }
+
+        [Test]
+        public void UDSReconnection()
+        {
+            using (var temporaryPath = new TemporaryPath())
+            {
+                CheckReconnection(new StatsdConfig
+                {
+                    StatsdServerName = StatsdBuilder.UnixDomainSocketPrefix + temporaryPath.Path,
+                });
+            }
+        }
+
+        private static void CheckReconnection(StatsdConfig config)
+        {
+            SocketServer server = null;
+
+            try
+            {
+                server = new SocketServer(config);
+                using (var service = new DogStatsdService())
+                {
+                    service.Configure(config);
+                    service.Increment("test1");
+                    Assert.AreEqual("test1:1|c", server.Stop().Single());
+                    server.Dispose();
+
+                    // Send a metric when the server is not running.
+                    service.Increment("test2");
+                    Task.Delay(TimeSpan.FromMilliseconds(500)).Wait();
+
+                    // Restart the server
+                    server = new SocketServer(config, removeUDSFileBeforeStarting: true);
+                    service.Increment("test3");
+                    service.Dispose();
+                    Assert.AreEqual("test3:1|c", server.Stop().Last());
+                }
+            }
+            finally
+            {
+                server?.Dispose();
+            }
+        }
+    }
+}

--- a/tests/StatsdClient.Tests/utils/SocketServer.cs
+++ b/tests/StatsdClient.Tests/utils/SocketServer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -18,7 +19,7 @@ namespace Tests.Utils
 
         private volatile bool _shutdown = false;
 
-        public SocketServer(StatsdConfig config)
+        public SocketServer(StatsdConfig config, bool removeUDSFileBeforeStarting = false)
         {
             EndPoint endPoint;
             int bufferSize;
@@ -27,6 +28,11 @@ namespace Tests.Utils
             if (serverName.StartsWith(StatsdBuilder.UnixDomainSocketPrefix))
             {
                 serverName = serverName.Substring(StatsdBuilder.UnixDomainSocketPrefix.Length);
+                if (removeUDSFileBeforeStarting)
+                {
+                    File.Delete(serverName);
+                }
+
                 _server = new Socket(AddressFamily.Unix, SocketType.Dgram, ProtocolType.Unspecified);
                 endPoint = new UnixEndPoint(serverName);
                 bufferSize = config.StatsdMaxUnixDomainSocketPacketSize;


### PR DESCRIPTION
If the DogStatsd server is stopped for a moment and then restarted, DogStatsd client cannot send new metrics.
This PR fixes this issue by using a not connected socket mode and by properly handle the exceptions.

Note: It start to be interesting to have an exception handler. It going to be added in a separate PR.

