### PR TITLE
Prepare client side aggregation

### DIFF
--- a/src/StatsdClient/Bufferize/IStatsBufferizeFactory.cs
+++ b/src/StatsdClient/Bufferize/IStatsBufferizeFactory.cs
@@ -12,10 +12,14 @@ namespace StatsdClient.Bufferize
     internal interface IStatsBufferizeFactory
     {
         StatsBufferize CreateStatsBufferize(
-          BufferBuilder bufferBuilder,
+          StatsRouter statsRouter,
           int workerMaxItemCount,
           TimeSpan? blockingQueueTimeout,
           TimeSpan maxIdleWaitBeforeSending);
+
+        StatsRouter CreateStatsRouter(
+            Serializers serializers,
+            BufferBuilder bufferBuilder);
 
         ITransport CreateUDPTransport(IPEndPoint endPoint);
 

--- a/src/StatsdClient/Bufferize/StatsBufferize.cs
+++ b/src/StatsdClient/Bufferize/StatsBufferize.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using StatsdClient.Statistic;
 using StatsdClient.Worker;
 
 namespace StatsdClient.Bufferize
@@ -9,26 +10,26 @@ namespace StatsdClient.Bufferize
     /// </summary>
     internal class StatsBufferize : IDisposable
     {
-        private readonly AsynchronousWorker<SerializedMetric> _worker;
+        private readonly AsynchronousWorker<Stats> _worker;
 
         public StatsBufferize(
-            BufferBuilder bufferBuilder,
+            StatsRouter statsRouter,
             int workerMaxItemCount,
             TimeSpan? blockingQueueTimeout,
             TimeSpan maxIdleWaitBeforeSending)
         {
-            var handler = new WorkerHandler(bufferBuilder, maxIdleWaitBeforeSending);
+            var handler = new WorkerHandler(statsRouter, maxIdleWaitBeforeSending);
 
-            // `handler` (and also `bufferBuilder`) do not need to be thread safe as long as workerMaxItemCount is 1.
-            this._worker = new AsynchronousWorker<SerializedMetric>(
+            // `handler` (and also `statsRouter`) do not need to be thread safe as long as `workerThreadCount` is 1.
+            this._worker = new AsynchronousWorker<Stats>(
                 handler,
                 new Waiter(),
-                1,
+                workerThreadCount: 1,
                 workerMaxItemCount,
                 blockingQueueTimeout);
         }
 
-        public bool Send(SerializedMetric serializedMetric)
+        public bool Send(Stats serializedMetric)
         {
             if (!this._worker.TryEnqueue(serializedMetric))
             {
@@ -44,27 +45,23 @@ namespace StatsdClient.Bufferize
             this._worker.Dispose();
         }
 
-        private class WorkerHandler : IAsynchronousWorkerHandler<SerializedMetric>
+        private class WorkerHandler : IAsynchronousWorkerHandler<Stats>
         {
-            private readonly BufferBuilder _bufferBuilder;
+            private readonly StatsRouter _statsRouter;
             private readonly TimeSpan _maxIdleWaitBeforeSending;
             private System.Diagnostics.Stopwatch _stopwatch;
 
-            public WorkerHandler(BufferBuilder bufferBuilder, TimeSpan maxIdleWaitBeforeSending)
+            public WorkerHandler(StatsRouter statsRouter, TimeSpan maxIdleWaitBeforeSending)
             {
-                _bufferBuilder = bufferBuilder;
+                _statsRouter = statsRouter;
                 _maxIdleWaitBeforeSending = maxIdleWaitBeforeSending;
             }
 
-            public void OnNewValue(SerializedMetric serializedMetric)
+            public void OnNewValue(Stats stats)
             {
-                using (serializedMetric)
+                using (stats)
                 {
-                    if (!_bufferBuilder.Add(serializedMetric))
-                    {
-                        throw new InvalidOperationException($"The metric size exceeds the buffer capacity: {serializedMetric.ToString()}");
-                    }
-
+                    _statsRouter.Route(stats);
                     _stopwatch = null;
                 }
             }
@@ -78,7 +75,7 @@ namespace StatsdClient.Bufferize
 
                 if (_stopwatch.ElapsedMilliseconds > _maxIdleWaitBeforeSending.TotalMilliseconds)
                 {
-                    this._bufferBuilder.HandleBufferAndReset();
+                    this._statsRouter.TryFlush();
 
                     return true;
                 }
@@ -88,7 +85,7 @@ namespace StatsdClient.Bufferize
 
             public void OnShutdown()
             {
-                this._bufferBuilder.HandleBufferAndReset();
+                this._statsRouter.TryFlush();
             }
         }
     }

--- a/src/StatsdClient/Bufferize/StatsBufferizeFactory.cs
+++ b/src/StatsdClient/Bufferize/StatsBufferizeFactory.cs
@@ -8,16 +8,23 @@ namespace StatsdClient.Bufferize
     internal class StatsBufferizeFactory : IStatsBufferizeFactory
     {
         public StatsBufferize CreateStatsBufferize(
-            BufferBuilder bufferBuilder,
+            StatsRouter statsRouter,
             int workerMaxItemCount,
             TimeSpan? blockingQueueTimeout,
             TimeSpan maxIdleWaitBeforeSending)
         {
             return new StatsBufferize(
-                bufferBuilder,
+                statsRouter,
                 workerMaxItemCount,
                 blockingQueueTimeout,
                 maxIdleWaitBeforeSending);
+        }
+
+        public StatsRouter CreateStatsRouter(
+            Serializers serializers,
+            BufferBuilder bufferBuilder)
+        {
+            return new StatsRouter(serializers, bufferBuilder);
         }
 
         public ITransport CreateUDPTransport(IPEndPoint endPoint)

--- a/src/StatsdClient/DogStatsdService.cs
+++ b/src/StatsdClient/DogStatsdService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using StatsdClient.Bufferize;
 
 namespace StatsdClient
@@ -71,8 +72,7 @@ namespace StatsdClient
         /// <param name="value">A given delta.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        /// <typeparam name="T">The type of the value.</typeparam>
-        public void Counter<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
+        public void Counter(string statName, double value, double sampleRate = 1.0, string[] tags = null)
         {
             _metricsSender?.SendMetric(MetricType.Counting, statName, value, sampleRate, tags);
         }
@@ -108,8 +108,7 @@ namespace StatsdClient
         /// <param name="value">The value of the gauge.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        /// <typeparam name="T">The type of the value.</typeparam>
-        public void Gauge<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
+        public void Gauge(string statName, double value, double sampleRate = 1.0, string[] tags = null)
         {
             _metricsSender?.SendMetric(MetricType.Gauge, statName, value, sampleRate, tags);
         }
@@ -121,8 +120,7 @@ namespace StatsdClient
         /// <param name="value">The value of the histogram.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        /// <typeparam name="T">The type of the value.</typeparam>
-        public void Histogram<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
+        public void Histogram(string statName, double value, double sampleRate = 1.0, string[] tags = null)
         {
             _metricsSender?.SendMetric(MetricType.Histogram, statName, value, sampleRate, tags);
         }
@@ -134,8 +132,7 @@ namespace StatsdClient
         /// <param name="value">The value of the distribution.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        /// <typeparam name="T">The type of the value.</typeparam>
-        public void Distribution<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
+        public void Distribution(string statName, double value, double sampleRate = 1.0, string[] tags = null)
         {
             _metricsSender?.SendMetric(MetricType.Distribution, statName, value, sampleRate, tags);
         }
@@ -150,7 +147,20 @@ namespace StatsdClient
         /// <typeparam name="T">The type of the value.</typeparam>
         public void Set<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.SendMetric(MetricType.Set, statName, value, sampleRate, tags);
+            var strValue = string.Format(CultureInfo.InvariantCulture, "{0}", value);
+            _metricsSender?.SendSetMetric(statName, strValue, sampleRate, tags);
+        }
+
+        /// <summary>
+        /// Records a value for the specified set.
+        /// </summary>
+        /// <param name="statName">The name of the metric.</param>
+        /// <param name="value">The value to set.</param>
+        /// <param name="sampleRate">Percentage of metric to be sent.</param>
+        /// <param name="tags">Array of tags to be added to the data.</param>
+        public void Set(string statName, string value, double sampleRate = 1.0, string[] tags = null)
+        {
+            _metricsSender?.SendSetMetric(statName, value, sampleRate, tags);
         }
 
         /// <summary>
@@ -160,8 +170,7 @@ namespace StatsdClient
         /// <param name="value">The time in millisecond.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        /// <typeparam name="T">The type of value parameter.</typeparam>
-        public void Timer<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
+        public void Timer(string statName, double value, double sampleRate = 1.0, string[] tags = null)
         {
             _metricsSender?.SendMetric(MetricType.Timing, statName, value, sampleRate, tags);
         }

--- a/src/StatsdClient/Dogstatsd.cs
+++ b/src/StatsdClient/Dogstatsd.cs
@@ -93,9 +93,8 @@ namespace StatsdClient
         /// <param name="value">A given delta.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        /// <typeparam name="T">The type of the value.</typeparam>
-        public static void Counter<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null) =>
-            _dogStatsdService.Counter<T>(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
+        public static void Counter(string statName, double value, double sampleRate = 1.0, string[] tags = null) =>
+            _dogStatsdService.Counter(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
 
         /// <summary>
         /// Increments the specified counter.
@@ -124,9 +123,8 @@ namespace StatsdClient
         /// <param name="value">The value of the gauge.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        /// <typeparam name="T">The type of the value.</typeparam>
-        public static void Gauge<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null) =>
-            _dogStatsdService.Gauge<T>(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
+        public static void Gauge(string statName, double value, double sampleRate = 1.0, string[] tags = null) =>
+            _dogStatsdService.Gauge(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
 
         /// <summary>
         /// Records a value for the specified named histogram.
@@ -135,9 +133,8 @@ namespace StatsdClient
         /// <param name="value">The value of the histogram.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        /// <typeparam name="T">The type of the value.</typeparam>
-        public static void Histogram<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null) =>
-            _dogStatsdService.Histogram<T>(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
+        public static void Histogram(string statName, double value, double sampleRate = 1.0, string[] tags = null) =>
+            _dogStatsdService.Histogram(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
 
         /// <summary>
         /// Records a value for the specified named distribution.
@@ -146,9 +143,8 @@ namespace StatsdClient
         /// <param name="value">The value of the distribution.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        /// <typeparam name="T">The type of the value.</typeparam>
-        public static void Distribution<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null) =>
-            _dogStatsdService.Distribution<T>(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
+        public static void Distribution(string statName, double value, double sampleRate = 1.0, string[] tags = null) =>
+            _dogStatsdService.Distribution(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
 
         /// <summary>
         /// Records a value for the specified set.
@@ -162,15 +158,24 @@ namespace StatsdClient
             _dogStatsdService.Set<T>(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
 
         /// <summary>
+        /// Records a value for the specified set.
+        /// </summary>
+        /// <param name="statName">The name of the metric.</param>
+        /// <param name="value">The value to set.</param>
+        /// <param name="sampleRate">Percentage of metric to be sent.</param>
+        /// <param name="tags">Array of tags to be added to the data.</param>
+        public static void Set(string statName, string value, double sampleRate = 1.0, string[] tags = null) =>
+            _dogStatsdService.Set(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
+
+        /// <summary>
         /// Records an execution time in milliseconds.
         /// </summary>
         /// <param name="statName">The name of the metric.</param>
         /// <param name="value">The time in millisecond.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        /// <typeparam name="T">The type of value parameter.</typeparam>
-        public static void Timer<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null) =>
-            _dogStatsdService.Timer<T>(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
+        public static void Timer(string statName, double value, double sampleRate = 1.0, string[] tags = null) =>
+            _dogStatsdService.Timer(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
 
         /// <summary>
         /// Creates a timer that records the execution time until Dispose is called on the returned value.

--- a/src/StatsdClient/IDogStatsd.cs
+++ b/src/StatsdClient/IDogStatsd.cs
@@ -27,8 +27,7 @@ namespace StatsdClient
         /// <param name="value">A given delta.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        /// <typeparam name="T">The type of the value.</typeparam>
-        void Counter<T>(string statName, T value, double sampleRate = 1, string[] tags = null);
+        void Counter(string statName, double value, double sampleRate = 1, string[] tags = null);
 
         /// <summary>
         /// Decrements the specified counter.
@@ -69,8 +68,7 @@ namespace StatsdClient
         /// <param name="value">The value of the gauge.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        /// <typeparam name="T">The type of the value.</typeparam>
-        void Gauge<T>(string statName, T value, double sampleRate = 1, string[] tags = null);
+        void Gauge(string statName, double value, double sampleRate = 1, string[] tags = null);
 
         /// <summary>
         /// Records a value for the specified named histogram.
@@ -79,8 +77,7 @@ namespace StatsdClient
         /// <param name="value">The value of the histogram.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        /// <typeparam name="T">The type of the value.</typeparam>
-        void Histogram<T>(string statName, T value, double sampleRate = 1, string[] tags = null);
+        void Histogram(string statName, double value, double sampleRate = 1, string[] tags = null);
 
         /// <summary>
         /// Records a value for the specified named distribution.
@@ -89,8 +86,7 @@ namespace StatsdClient
         /// <param name="value">The value of the distribution.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        /// <typeparam name="T">The type of the value.</typeparam>
-        void Distribution<T>(string statName, T value, double sampleRate = 1, string[] tags = null);
+        void Distribution(string statName, double value, double sampleRate = 1, string[] tags = null);
 
         /// <summary>
         /// Increments the specified counter.
@@ -110,6 +106,15 @@ namespace StatsdClient
         /// <param name="tags">Array of tags to be added to the data.</param>
         /// <typeparam name="T">The type of the value.</typeparam>
         void Set<T>(string statName, T value, double sampleRate = 1, string[] tags = null);
+
+        /// <summary>
+        /// Records a value for the specified set.
+        /// </summary>
+        /// <param name="statName">The name of the metric.</param>
+        /// <param name="value">The value to set.</param>
+        /// <param name="sampleRate">Percentage of metric to be sent.</param>
+        /// <param name="tags">Array of tags to be added to the data.</param>
+        void Set(string statName, string value, double sampleRate = 1, string[] tags = null);
 
         /// <summary>
         /// Creates a timer that records the execution time until Dispose is called on the returned value.
@@ -147,8 +152,7 @@ namespace StatsdClient
         /// <param name="value">The time in millisecond.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        /// <typeparam name="T">The type of value parameter.</typeparam>
-        void Timer<T>(string statName, T value, double sampleRate = 1, string[] tags = null);
+        void Timer(string statName, double value, double sampleRate = 1, string[] tags = null);
 
         /// <summary>
         /// Records a run status for the specified named service check.

--- a/src/StatsdClient/MetricsSender.cs
+++ b/src/StatsdClient/MetricsSender.cs
@@ -46,8 +46,8 @@ namespace StatsdClient
         {
             if (_randomGenerator.ShouldSend(sampleRate))
             {
-                var optionalSerializedMetric = _serializers.MetricSerializer.Serialize(metricType, name, value, sampleRate, tags);
-                Send(optionalSerializedMetric, () => _optionalTelemetry?.OnMetricSent());
+                // var optionalSerializedMetric = _serializers.MetricSerializer.Serialize(metricType, name, value, sampleRate, tags);
+                // Send(optionalSerializedMetric, () => _optionalTelemetry?.OnMetricSent());
             }
         }
 

--- a/src/StatsdClient/MetricsSender.cs
+++ b/src/StatsdClient/MetricsSender.cs
@@ -42,7 +42,21 @@ namespace StatsdClient
             // Send(optionalSerializedMetric, () => _optionalTelemetry?.OnServiceCheckSent());
         }
 
-        public void SendMetric<T>(MetricType metricType, string name, T value, double sampleRate = 1.0, string[] tags = null)
+        public void SendMetric(MetricType metricType, string name, double value, double sampleRate = 1.0, string[] tags = null)
+        {
+            if (metricType == MetricType.Set)
+            {
+                throw new ArgumentException($"{nameof(SendMetric)} does not support `MetricType.Set`.");
+            }
+
+            if (_randomGenerator.ShouldSend(sampleRate))
+            {
+                // var optionalSerializedMetric = _serializers.MetricSerializer.Serialize(metricType, name, value, sampleRate, tags);
+                // Send(optionalSerializedMetric, () => _optionalTelemetry?.OnMetricSent());
+            }
+        }
+
+        public void SendSetMetric(string name, string value, double sampleRate = 1.0, string[] tags = null)
         {
             if (_randomGenerator.ShouldSend(sampleRate))
             {

--- a/src/StatsdClient/MetricsSender.cs
+++ b/src/StatsdClient/MetricsSender.cs
@@ -35,7 +35,7 @@ namespace StatsdClient
             if (TryDequeueStats(out var stats))
             {
                 stats.Kind = StatsKind.Event;
-                stats.Tags = tags;
+                stats.Event.Tags = tags;
                 stats.Event.Title = title;
                 stats.Event.Text = text;
                 stats.Event.AlertType = alertType;
@@ -55,7 +55,7 @@ namespace StatsdClient
             if (TryDequeueStats(out var stats))
             {
                 stats.Kind = StatsKind.ServiceCheck;
-                stats.Tags = tags;
+                stats.ServiceCheck.Tags = tags;
                 stats.ServiceCheck.Name = name;
                 stats.ServiceCheck.Status = status;
                 stats.ServiceCheck.Timestamp = timestamp;
@@ -78,7 +78,7 @@ namespace StatsdClient
                 if (TryDequeueStats(out var stats))
                 {
                     stats.Kind = StatsKind.Metric;
-                    stats.Tags = tags;
+                    stats.Metric.Tags = tags;
                     stats.Metric.MetricType = metricType;
                     stats.Metric.StatName = name;
                     stats.Metric.SampleRate = sampleRate;
@@ -96,7 +96,7 @@ namespace StatsdClient
                 if (TryDequeueStats(out var stats))
                 {
                     stats.Kind = StatsKind.Metric;
-                    stats.Tags = tags;
+                    stats.Metric.Tags = tags;
                     stats.Metric.MetricType = MetricType.Set;
                     stats.Metric.StatName = name;
                     stats.Metric.SampleRate = sampleRate;

--- a/src/StatsdClient/MetricsSender.cs
+++ b/src/StatsdClient/MetricsSender.cs
@@ -30,9 +30,9 @@ namespace StatsdClient
 
         public void SendEvent(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, string[] tags = null, bool truncateIfTooLong = false)
         {
-            truncateIfTooLong = truncateIfTooLong || _truncateIfTooLong;
-            var optionalSerializedMetric = _serializers.EventSerializer.Serialize(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, tags, truncateIfTooLong);
-            Send(optionalSerializedMetric, () => _optionalTelemetry?.OnEventSent());
+            // truncateIfTooLong = truncateIfTooLong || _truncateIfTooLong;
+            // var optionalSerializedMetric = _serializers.EventSerializer.Serialize(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, tags, truncateIfTooLong);
+            // Send(optionalSerializedMetric, () => _optionalTelemetry?.OnEventSent());
         }
 
         public void SendServiceCheck(string name, int status, int? timestamp = null, string hostname = null, string[] tags = null, string serviceCheckMessage = null, bool truncateIfTooLong = false)

--- a/src/StatsdClient/MetricsSender.cs
+++ b/src/StatsdClient/MetricsSender.cs
@@ -37,9 +37,9 @@ namespace StatsdClient
 
         public void SendServiceCheck(string name, int status, int? timestamp = null, string hostname = null, string[] tags = null, string serviceCheckMessage = null, bool truncateIfTooLong = false)
         {
-            truncateIfTooLong = truncateIfTooLong || _truncateIfTooLong;
-            var optionalSerializedMetric = _serializers.ServiceCheckSerializer.Serialize(name, status, timestamp, hostname, tags, serviceCheckMessage, truncateIfTooLong);
-            Send(optionalSerializedMetric, () => _optionalTelemetry?.OnServiceCheckSent());
+            // truncateIfTooLong = truncateIfTooLong || _truncateIfTooLong;
+            // var optionalSerializedMetric = _serializers.ServiceCheckSerializer.Serialize(name, status, timestamp, hostname, tags, serviceCheckMessage, truncateIfTooLong);
+            // Send(optionalSerializedMetric, () => _optionalTelemetry?.OnServiceCheckSent());
         }
 
         public void SendMetric<T>(MetricType metricType, string name, T value, double sampleRate = 1.0, string[] tags = null)

--- a/src/StatsdClient/SerializedMetric.cs
+++ b/src/StatsdClient/SerializedMetric.cs
@@ -1,15 +1,9 @@
 using System.Text;
-using StatsdClient.Utils;
 
 namespace StatsdClient
 {
-    internal class SerializedMetric : AbstractPoolObject
+    internal class SerializedMetric
     {
-        public SerializedMetric(Pool<SerializedMetric> pool)
-        : base(pool)
-        {
-        }
-
         public StringBuilder Builder { get; } = new StringBuilder();
 
         public int CopyToChars(char[] charsBuffers)
@@ -29,7 +23,7 @@ namespace StatsdClient
             return Builder.ToString();
         }
 
-        public override void Reset()
+        public void Reset()
         {
             Builder.Clear();
         }

--- a/src/StatsdClient/Serializer/EventSerializer.cs
+++ b/src/StatsdClient/Serializer/EventSerializer.cs
@@ -14,7 +14,7 @@ namespace StatsdClient
             _serializerHelper = serializerHelper;
         }
 
-        public void SerializeTo(ref StatsEvent statsEvent, string[] tags, SerializedMetric serializedMetric)
+        public void SerializeTo(ref StatsEvent statsEvent, SerializedMetric serializedMetric)
         {
             serializedMetric.Reset();
             string processedTitle = SerializerHelper.EscapeContent(statsEvent.Title);
@@ -41,7 +41,7 @@ namespace StatsdClient
             SerializerHelper.AppendIfNotNull(builder, "|s:", statsEvent.SourceType);
             SerializerHelper.AppendIfNotNull(builder, "|t:", statsEvent.AlertType);
 
-            _serializerHelper.AppendTags(builder, tags);
+            _serializerHelper.AppendTags(builder, statsEvent.Tags);
 
             if (builder.Length > MaxSize)
             {
@@ -58,7 +58,7 @@ namespace StatsdClient
                     }
 
                     statsEvent.TruncateIfTooLong = true;
-                    SerializeTo(ref statsEvent, tags, serializedMetric);
+                    SerializeTo(ref statsEvent, serializedMetric);
                 }
                 else
                 {

--- a/src/StatsdClient/Serializer/EventSerializer.cs
+++ b/src/StatsdClient/Serializer/EventSerializer.cs
@@ -14,17 +14,11 @@ namespace StatsdClient
             _serializerHelper = serializerHelper;
         }
 
-        public SerializedMetric Serialize(ref StatsEvent statsEvent, string[] tags)
+        public void SerializeTo(ref StatsEvent statsEvent, string[] tags, SerializedMetric serializedMetric)
         {
+            serializedMetric.Reset();
             string processedTitle = SerializerHelper.EscapeContent(statsEvent.Title);
             string processedText = SerializerHelper.EscapeContent(statsEvent.Text);
-
-            var serializedMetric = _serializerHelper.GetOptionalSerializedMetric();
-            if (serializedMetric == null)
-            {
-                return null;
-            }
-
             var builder = serializedMetric.Builder;
 
             builder.Append("_e{");
@@ -64,15 +58,13 @@ namespace StatsdClient
                     }
 
                     statsEvent.TruncateIfTooLong = true;
-                    return Serialize(ref statsEvent, tags);
+                    SerializeTo(ref statsEvent, tags, serializedMetric);
                 }
                 else
                 {
                     throw new Exception(string.Format("Event {0} payload is too big (more than 8kB)", statsEvent.Title));
                 }
             }
-
-            return serializedMetric;
         }
     }
 }

--- a/src/StatsdClient/Serializer/MetricSerializer.cs
+++ b/src/StatsdClient/Serializer/MetricSerializer.cs
@@ -27,7 +27,7 @@ namespace StatsdClient
             _prefix = string.IsNullOrEmpty(prefix) ? string.Empty : prefix + ".";
         }
 
-        public void SerializeTo(ref StatsMetric metricStats, string[] tags, SerializedMetric serializedMetric)
+        public void SerializeTo(ref StatsMetric metricStats, SerializedMetric serializedMetric)
         {
             serializedMetric.Reset();
 
@@ -51,7 +51,7 @@ namespace StatsdClient
                 builder.AppendFormat(CultureInfo.InvariantCulture, "|@{0}", metricStats.SampleRate);
             }
 
-            _serializerHelper.AppendTags(builder, tags);
+            _serializerHelper.AppendTags(builder, metricStats.Tags);
         }
     }
 }

--- a/src/StatsdClient/Serializer/MetricSerializer.cs
+++ b/src/StatsdClient/Serializer/MetricSerializer.cs
@@ -27,13 +27,9 @@ namespace StatsdClient
             _prefix = string.IsNullOrEmpty(prefix) ? string.Empty : prefix + ".";
         }
 
-        public SerializedMetric Serialize(ref StatsMetric metricStats, string[] tags)
+        public void SerializeTo(ref StatsMetric metricStats, string[] tags, SerializedMetric serializedMetric)
         {
-            var serializedMetric = _serializerHelper.GetOptionalSerializedMetric();
-            if (serializedMetric == null)
-            {
-                return null;
-            }
+            serializedMetric.Reset();
 
             var builder = serializedMetric.Builder;
             var unit = _commandToUnit[metricStats.MetricType];
@@ -56,7 +52,6 @@ namespace StatsdClient
             }
 
             _serializerHelper.AppendTags(builder, tags);
-            return serializedMetric;
         }
     }
 }

--- a/src/StatsdClient/Serializer/SerializerHelper.cs
+++ b/src/StatsdClient/Serializer/SerializerHelper.cs
@@ -6,13 +6,11 @@ namespace StatsdClient
     internal class SerializerHelper
     {
         private static readonly string[] EmptyArray = new string[0];
-        private readonly Pool<SerializedMetric> _pool;
         private readonly string _constantTags;
 
-        public SerializerHelper(string[] constantTags, int poolMaxAllocation)
+        public SerializerHelper(string[] constantTags)
         {
             _constantTags = constantTags != null ? string.Join(",", constantTags) : string.Empty;
-            _pool = new Pool<SerializedMetric>(pool => new SerializedMetric(pool), poolMaxAllocation);
         }
 
         public static string EscapeContent(string content)
@@ -34,12 +32,6 @@ namespace StatsdClient
                 builder.Append(prefix);
                 builder.Append(value);
             }
-        }
-
-        public SerializedMetric GetOptionalSerializedMetric()
-        {
-            _pool.TryDequeue(out var serializedMetric);
-            return serializedMetric;
         }
 
         public void AppendTags(StringBuilder builder, string[] tags)

--- a/src/StatsdClient/Serializer/ServiceCheckSerializer.cs
+++ b/src/StatsdClient/Serializer/ServiceCheckSerializer.cs
@@ -15,7 +15,7 @@ namespace StatsdClient
             _serializerHelper = serializerHelper;
         }
 
-        public void SerializeTo(ref StatsServiceCheck sc, string[] tags, SerializedMetric serializedMetric)
+        public void SerializeTo(ref StatsServiceCheck sc, SerializedMetric serializedMetric)
         {
             serializedMetric.Reset();
 
@@ -35,7 +35,7 @@ namespace StatsdClient
 
             SerializerHelper.AppendIfNotNull(builder, "|h:", sc.Hostname);
 
-            _serializerHelper.AppendTags(builder, tags);
+            _serializerHelper.AppendTags(builder, sc.Tags);
 
             // Note: this must always be appended to the result last.
             SerializerHelper.AppendIfNotNull(builder, "|m:", processedMessage);
@@ -44,7 +44,7 @@ namespace StatsdClient
             if (sc.ServiceCheckMessage != null)
             {
                 sc.TruncateIfTooLong = true;
-                SerializeTo(ref sc, tags, serializedMetric);
+                SerializeTo(ref sc, serializedMetric);
             }
         }
 

--- a/src/StatsdClient/Serializer/ServiceCheckSerializer.cs
+++ b/src/StatsdClient/Serializer/ServiceCheckSerializer.cs
@@ -15,13 +15,9 @@ namespace StatsdClient
             _serializerHelper = serializerHelper;
         }
 
-        public SerializedMetric Serialize(ref StatsServiceCheck sc, string[] tags)
+        public void SerializeTo(ref StatsServiceCheck sc, string[] tags, SerializedMetric serializedMetric)
         {
-            var serializedMetric = _serializerHelper.GetOptionalSerializedMetric();
-            if (serializedMetric == null)
-            {
-                return null;
-            }
+            serializedMetric.Reset();
 
             var builder = serializedMetric.Builder;
 
@@ -48,10 +44,8 @@ namespace StatsdClient
             if (sc.ServiceCheckMessage != null)
             {
                 sc.TruncateIfTooLong = true;
-                return Serialize(ref sc, tags);
+                SerializeTo(ref sc, tags, serializedMetric);
             }
-
-            return serializedMetric;
         }
 
         private static string TruncateMessageIfRequired(

--- a/src/StatsdClient/Statistic/Stats.cs
+++ b/src/StatsdClient/Statistic/Stats.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using StatsdClient.Utils;
 
 namespace StatsdClient.Statistic
 {
@@ -8,7 +9,7 @@ namespace StatsdClient.Statistic
     /// The field `Metric`, `ServiceCheck` and `Event` are structures for performance reasons. These
     /// fields are embeded inside Stats and so do not require extra allocations.
     /// </summary>
-    internal class Stats : IDisposable
+    internal class Stats : AbstractPoolObject
     {
         // The next 3 fields are not properties because we want to take a reference on them to avoid a copy.
         [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:FieldsMustBePrivate", Justification = "Take a reference on struct")]
@@ -20,13 +21,18 @@ namespace StatsdClient.Statistic
         [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:FieldsMustBePrivate", Justification = "Take a reference on struct")]
         public StatsEvent Event;
 
+        public Stats(IPool pool)
+            : base(pool)
+        {
+        }
+
         public string[] Tags { get; set; }
 
         public StatsKind Kind { get; set; }
 
-        public void Dispose()
+        public override void Reset()
         {
-            // TODO
+            // Nothing
         }
     }
 }

--- a/src/StatsdClient/Statistic/Stats.cs
+++ b/src/StatsdClient/Statistic/Stats.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace StatsdClient.Statistic
+{
+    /// <summary>
+    /// Stats stores the data for a metric or a service check or an event.
+    /// The field `Metric`, `ServiceCheck` and `Event` are structures for performance reasons. These
+    /// fields are embeded inside Stats and so do not require extra allocations.
+    /// </summary>
+    internal class Stats : IDisposable
+    {
+        // The next 3 fields are not properties because we want to take a reference on them to avoid a copy.
+        [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:FieldsMustBePrivate", Justification = "Take a reference on struct")]
+        public StatsMetric Metric;
+
+        [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:FieldsMustBePrivate", Justification = "Take a reference on struct")]
+        public StatsServiceCheck ServiceCheck;
+
+        [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:FieldsMustBePrivate", Justification = "Take a reference on struct")]
+        public StatsEvent Event;
+
+        public string[] Tags { get; set; }
+
+        public StatsKind Kind { get; set; }
+
+        public void Dispose()
+        {
+            // TODO
+        }
+    }
+}

--- a/src/StatsdClient/Statistic/Stats.cs
+++ b/src/StatsdClient/Statistic/Stats.cs
@@ -28,7 +28,7 @@ namespace StatsdClient.Statistic
 
         public StatsKind Kind { get; set; }
 
-        public override void Reset()
+        protected override void DoReset()
         {
             // Nothing
         }

--- a/src/StatsdClient/Statistic/Stats.cs
+++ b/src/StatsdClient/Statistic/Stats.cs
@@ -26,8 +26,6 @@ namespace StatsdClient.Statistic
         {
         }
 
-        public string[] Tags { get; set; }
-
         public StatsKind Kind { get; set; }
 
         public override void Reset()

--- a/src/StatsdClient/Statistic/StatsEvent.cs
+++ b/src/StatsdClient/Statistic/StatsEvent.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace StatsdClient.Statistic
+{
+    /// <summary>
+    /// Store the data for an event.
+    /// </summary>
+    internal struct StatsEvent
+    {
+        public string Title { get; set; }
+
+        public string Text { get; set; }
+
+        public string AlertType { get; set; }
+
+        public string AggregationKey { get; set; }
+
+        public string SourceType { get; set; }
+
+        public int? DateHappened { get; set; }
+
+        public string Priority { get; set; }
+
+        public string Hostname { get; set; }
+
+        public bool TruncateIfTooLong { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            throw new NotSupportedException("The default implementation has performance issues.");
+        }
+
+        public override int GetHashCode()
+        {
+            throw new NotSupportedException("The default implementation has performance issues.");
+        }
+    }
+}

--- a/src/StatsdClient/Statistic/StatsEvent.cs
+++ b/src/StatsdClient/Statistic/StatsEvent.cs
@@ -25,6 +25,8 @@ namespace StatsdClient.Statistic
 
         public bool TruncateIfTooLong { get; set; }
 
+        public string[] Tags { get; set; }
+
         public override bool Equals(object obj)
         {
             throw new NotSupportedException("The default implementation has performance issues.");

--- a/src/StatsdClient/Statistic/StatsKind.cs
+++ b/src/StatsdClient/Statistic/StatsKind.cs
@@ -1,0 +1,9 @@
+namespace StatsdClient.Statistic
+{
+    internal enum StatsKind
+    {
+        Metric,
+        ServiceCheck,
+        Event,
+    }
+}

--- a/src/StatsdClient/Statistic/StatsMetric.cs
+++ b/src/StatsdClient/Statistic/StatsMetric.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace StatsdClient.Statistic
+{
+    /// <summary>
+    /// Store the data for a metric.
+    /// </summary>
+    internal struct StatsMetric
+    {
+        public MetricType MetricType { get; set; }
+
+        public string StatName { get; set; }
+
+        public double NumericValue { get; set; } // Use for all `MetricType` excepts for `MetricType.Set`
+
+        public string StringValue { get; set; } // Use only for `MetricType.Set`
+
+        public double SampleRate { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            throw new NotSupportedException("The default implementation has performance issues.");
+        }
+
+        public override int GetHashCode()
+        {
+            throw new NotSupportedException("The default implementation has performance issues.");
+        }
+    }
+}

--- a/src/StatsdClient/Statistic/StatsMetric.cs
+++ b/src/StatsdClient/Statistic/StatsMetric.cs
@@ -17,6 +17,8 @@ namespace StatsdClient.Statistic
 
         public double SampleRate { get; set; }
 
+        public string[] Tags { get; set; }
+
         public override bool Equals(object obj)
         {
             throw new NotSupportedException("The default implementation has performance issues.");

--- a/src/StatsdClient/Statistic/StatsServiceCheck.cs
+++ b/src/StatsdClient/Statistic/StatsServiceCheck.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace StatsdClient.Statistic
+{
+    /// <summary>
+    /// Store the data for a service check.
+    /// </summary>
+    internal struct StatsServiceCheck
+    {
+        public string Name { get; set; }
+
+        public int Status { get; set; }
+
+        public int? Timestamp { get; set; }
+
+        public string Hostname { get; set; }
+
+        public string ServiceCheckMessage { get; set; }
+
+        public bool TruncateIfTooLong { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            throw new NotSupportedException("The default implementation has performance issues.");
+        }
+
+        public override int GetHashCode()
+        {
+            throw new NotSupportedException("The default implementation has performance issues.");
+        }
+    }
+}

--- a/src/StatsdClient/Statistic/StatsServiceCheck.cs
+++ b/src/StatsdClient/Statistic/StatsServiceCheck.cs
@@ -19,6 +19,8 @@ namespace StatsdClient.Statistic
 
         public bool TruncateIfTooLong { get; set; }
 
+        public string[] Tags { get; set; }
+
         public override bool Equals(object obj)
         {
             throw new NotSupportedException("The default implementation has performance issues.");

--- a/src/StatsdClient/StatsRouter.cs
+++ b/src/StatsdClient/StatsRouter.cs
@@ -1,0 +1,57 @@
+using System;
+using StatsdClient.Bufferize;
+using StatsdClient.Statistic;
+
+namespace StatsdClient
+{
+    /// <summary>
+    /// Route `Stats` instance.
+    /// Route always to BufferBuilder.
+    /// </summary>
+    internal class StatsRouter
+    {
+        private readonly Serializers _serializers;
+        private readonly BufferBuilder _bufferBuilder;
+
+        public StatsRouter(
+            Serializers serializers,
+            BufferBuilder bufferBuilder)
+        {
+            _serializers = serializers;
+            _bufferBuilder = bufferBuilder;
+        }
+
+        public void Route(Stats stats)
+        {
+            SerializedMetric serializedMetric = null;
+
+            switch (stats.Kind)
+            {
+                case StatsKind.Event:
+                    serializedMetric = this._serializers.EventSerializer.Serialize(ref stats.Event, stats.Tags);
+                    break;
+                case StatsKind.Metric:
+                    serializedMetric = this._serializers.MetricSerializer.Serialize(ref stats.Metric, stats.Tags);
+                    break;
+                case StatsKind.ServiceCheck:
+                    serializedMetric = this._serializers.ServiceCheckSerializer.Serialize(ref stats.ServiceCheck, stats.Tags);
+                    break;
+                default:
+                    throw new ArgumentException($"{stats.Kind} is not supported");
+            }
+
+            if (serializedMetric != null)
+            {
+                if (!_bufferBuilder.Add(serializedMetric))
+                {
+                    throw new InvalidOperationException($"The metric size exceeds the buffer capacity: {serializedMetric.ToString()}");
+                }
+            }
+        }
+
+        public void TryFlush()
+        {
+            _bufferBuilder.HandleBufferAndReset();
+        }
+    }
+}

--- a/src/StatsdClient/StatsRouter.cs
+++ b/src/StatsdClient/StatsRouter.cs
@@ -27,13 +27,13 @@ namespace StatsdClient
             switch (stats.Kind)
             {
                 case StatsKind.Event:
-                    this._serializers.EventSerializer.SerializeTo(ref stats.Event, stats.Tags, _serializedMetric);
+                    this._serializers.EventSerializer.SerializeTo(ref stats.Event, _serializedMetric);
                     break;
                 case StatsKind.Metric:
-                    this._serializers.MetricSerializer.SerializeTo(ref stats.Metric, stats.Tags, _serializedMetric);
+                    this._serializers.MetricSerializer.SerializeTo(ref stats.Metric, _serializedMetric);
                     break;
                 case StatsKind.ServiceCheck:
-                    this._serializers.ServiceCheckSerializer.SerializeTo(ref stats.ServiceCheck, stats.Tags, _serializedMetric);
+                    this._serializers.ServiceCheckSerializer.SerializeTo(ref stats.ServiceCheck, _serializedMetric);
                     break;
                 default:
                     throw new ArgumentException($"{stats.Kind} is not supported");

--- a/src/StatsdClient/StatsdBuilder.cs
+++ b/src/StatsdClient/StatsdBuilder.cs
@@ -43,7 +43,8 @@ namespace StatsdClient
                 new RandomGenerator(),
                 new StopWatchFactory(),
                 telemetry,
-                config.StatsdTruncateIfTooLong);
+                config.StatsdTruncateIfTooLong,
+                config.Advanced.MaxMetricsInAsyncQueue * 2);
             return new StatsdData(metricsSender, statsBufferize, transport, telemetry);
         }
 

--- a/src/StatsdClient/StatsdBuilder.cs
+++ b/src/StatsdClient/StatsdBuilder.cs
@@ -75,9 +75,7 @@ namespace StatsdClient
             string[] constantTags,
             int maxMetricsInAsyncQueue)
         {
-            // 100 is an arbitrary value. poolMaxAllocation must be a little greater than maxMetricsInAsyncQueue.
-            var poolMaxAllocation = maxMetricsInAsyncQueue + 100;
-            var serializerHelper = new SerializerHelper(constantTags, poolMaxAllocation);
+            var serializerHelper = new SerializerHelper(constantTags);
 
             return new Serializers
             {

--- a/src/StatsdClient/StatsdBuilder.cs
+++ b/src/StatsdClient/StatsdBuilder.cs
@@ -42,7 +42,6 @@ namespace StatsdClient
                 statsBufferize,
                 new RandomGenerator(),
                 new StopWatchFactory(),
-                serializers,
                 telemetry,
                 config.StatsdTruncateIfTooLong);
             return new StatsdData(metricsSender, statsBufferize, transport, telemetry);

--- a/src/StatsdClient/StatsdBuilder.cs
+++ b/src/StatsdClient/StatsdBuilder.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Mono.Unix;
-using StatsdClient.Aggregator;
 using StatsdClient.Bufferize;
 using StatsdClient.Transport;
 

--- a/tests/StatsdClient.Tests/Bufferize/BufferBuilderTests.cs
+++ b/tests/StatsdClient.Tests/Bufferize/BufferBuilderTests.cs
@@ -57,7 +57,7 @@ namespace Tests
 
         private static SerializedMetric CreateSerializedMetric(char c, int count)
         {
-            var serializedMetric = new SerializedMetric(null);
+            var serializedMetric = new SerializedMetric();
             serializedMetric.Builder.Append(new string(c, count));
 
             return serializedMetric;

--- a/tests/StatsdClient.Tests/Bufferize/StatsBufferizeTests.cs
+++ b/tests/StatsdClient.Tests/Bufferize/StatsBufferizeTests.cs
@@ -14,6 +14,7 @@ namespace Tests
     public class StatsBufferizeTests
     {
         [Test]
+        [Timeout(10000)]
         public void StatsBufferize()
         {
             var handler = new BufferBuilderHandlerMock();
@@ -25,7 +26,8 @@ namespace Tests
             var statsRouter = new StatsRouter(serializers, bufferBuilder);
             using (var statsBufferize = new StatsBufferize(statsRouter, 10, null, TimeSpan.Zero))
             {
-                var stats = new Stats(null) { Kind = StatsKind.Event };
+                var pool = new Pool<Stats>(p => new Stats(p), 1);
+                var stats = new Stats(pool) { Kind = StatsKind.Event };
                 stats.Event.Text = "test";
                 stats.Event.Title = "title";
 

--- a/tests/StatsdClient.Tests/Bufferize/StatsBufferizeTests.cs
+++ b/tests/StatsdClient.Tests/Bufferize/StatsBufferizeTests.cs
@@ -20,7 +20,7 @@ namespace Tests
             var bufferBuilder = new BufferBuilder(handler, 30, "\n");
             var serializers = new Serializers
             {
-                EventSerializer = new EventSerializer(new SerializerHelper(null, 10)),
+                EventSerializer = new EventSerializer(new SerializerHelper(null)),
             };
             var statsRouter = new StatsRouter(serializers, bufferBuilder);
             using (var statsBufferize = new StatsBufferize(statsRouter, 10, null, TimeSpan.Zero))

--- a/tests/StatsdClient.Tests/Bufferize/StatsBufferizeTests.cs
+++ b/tests/StatsdClient.Tests/Bufferize/StatsBufferizeTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using StatsdClient;
 using StatsdClient.Bufferize;
+using StatsdClient.Statistic;
 using StatsdClient.Utils;
 
 namespace Tests
@@ -16,20 +17,26 @@ namespace Tests
         public void StatsBufferize()
         {
             var handler = new BufferBuilderHandlerMock();
-            var bufferBuilder = new BufferBuilder(handler, 3, "\n");
-            using (var statsBufferize = new StatsBufferize(bufferBuilder, 10, null, TimeSpan.Zero))
+            var bufferBuilder = new BufferBuilder(handler, 30, "\n");
+            var serializers = new Serializers
             {
-                var serializedMetric = new SerializedMetric(new Pool<SerializedMetric>(p => new SerializedMetric(p), 10));
-                serializedMetric.Builder.Append("1");
+                EventSerializer = new EventSerializer(new SerializerHelper(null, 10)),
+            };
+            var statsRouter = new StatsRouter(serializers, bufferBuilder);
+            using (var statsBufferize = new StatsBufferize(statsRouter, 10, null, TimeSpan.Zero))
+            {
+                var stats = new Stats { Kind = StatsKind.Event };
+                stats.Event.Text = "test";
+                stats.Event.Title = "title";
 
-                statsBufferize.Send(serializedMetric);
+                statsBufferize.Send(stats);
                 while (handler.Buffer == null)
                 {
                     Task.Delay(TimeSpan.FromMilliseconds(1)).Wait();
                 }
 
                 // Sent because buffer is full.
-                Assert.AreEqual("1", Encoding.UTF8.GetString(handler.Buffer));
+                Assert.AreEqual("_e{5,4}:title|test", Encoding.UTF8.GetString(handler.Buffer));
             }
         }
     }

--- a/tests/StatsdClient.Tests/Bufferize/StatsBufferizeTests.cs
+++ b/tests/StatsdClient.Tests/Bufferize/StatsBufferizeTests.cs
@@ -25,7 +25,7 @@ namespace Tests
             var statsRouter = new StatsRouter(serializers, bufferBuilder);
             using (var statsBufferize = new StatsBufferize(statsRouter, 10, null, TimeSpan.Zero))
             {
-                var stats = new Stats { Kind = StatsKind.Event };
+                var stats = new Stats(null) { Kind = StatsKind.Event };
                 stats.Event.Text = "test";
                 stats.Event.Title = "title";
 

--- a/tests/StatsdClient.Tests/Serializer/EventSerializerTests.cs
+++ b/tests/StatsdClient.Tests/Serializer/EventSerializerTests.cs
@@ -69,7 +69,7 @@ namespace StatsdClient.Tests
                 () =>
                 {
                     var statsEvent = new StatsEvent { Title = title + "x", Text = "Text" };
-                    serializer.SerializeTo(ref statsEvent, null, new SerializedMetric());
+                    serializer.SerializeTo(ref statsEvent, new SerializedMetric());
                 });
             Assert.That(exception.Message, Contains.Substring("payload is too big"));
         }
@@ -152,10 +152,11 @@ namespace StatsdClient.Tests
                 Priority = priority,
                 Hostname = hostname,
                 TruncateIfTooLong = truncateIfTooLong,
+                Tags = tags,
             };
 
             var serializedMetric = new SerializedMetric();
-            serializer.SerializeTo(ref statsEvent, tags, serializedMetric);
+            serializer.SerializeTo(ref statsEvent, serializedMetric);
             Assert.AreEqual(expectValue, serializedMetric.ToString());
         }
 

--- a/tests/StatsdClient.Tests/Serializer/EventSerializerTests.cs
+++ b/tests/StatsdClient.Tests/Serializer/EventSerializerTests.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using Moq;
 using NUnit.Framework;
+using StatsdClient.Statistic;
 
 namespace StatsdClient.Tests
 {
@@ -65,7 +66,11 @@ namespace StatsdClient.Tests
 
             var serializer = CreateSerializer();
             var exception = Assert.Throws<Exception>(
-                () => serializer.Serialize(title + "x", "text", null, null, null, null, null, null, null));
+                () =>
+                {
+                    var statsEvent = new StatsEvent { Title = title + "x", Text = "Text" };
+                    serializer.Serialize(ref statsEvent, null);
+                });
             Assert.That(exception.Message, Contains.Substring("payload is too big"));
         }
 
@@ -136,17 +141,20 @@ namespace StatsdClient.Tests
             bool truncateIfTooLong = false)
         {
             var serializer = CreateSerializer();
-            var serializedMetric = serializer.Serialize(
-                title,
-                text,
-                alertType,
-                aggregationKey,
-                sourceType,
-                dateHappened,
-                priority,
-                hostname,
-                tags,
-                truncateIfTooLong);
+            var statsEvent = new StatsEvent
+            {
+                Title = title,
+                Text = text,
+                AlertType = alertType,
+                AggregationKey = aggregationKey,
+                SourceType = sourceType,
+                DateHappened = dateHappened,
+                Priority = priority,
+                Hostname = hostname,
+                TruncateIfTooLong = truncateIfTooLong,
+            };
+
+            var serializedMetric = serializer.Serialize(ref statsEvent, tags);
             Assert.AreEqual(expectValue, serializedMetric.ToString());
         }
 

--- a/tests/StatsdClient.Tests/Serializer/EventSerializerTests.cs
+++ b/tests/StatsdClient.Tests/Serializer/EventSerializerTests.cs
@@ -69,7 +69,7 @@ namespace StatsdClient.Tests
                 () =>
                 {
                     var statsEvent = new StatsEvent { Title = title + "x", Text = "Text" };
-                    serializer.Serialize(ref statsEvent, null);
+                    serializer.SerializeTo(ref statsEvent, null, new SerializedMetric());
                 });
             Assert.That(exception.Message, Contains.Substring("payload is too big"));
         }
@@ -154,13 +154,14 @@ namespace StatsdClient.Tests
                 TruncateIfTooLong = truncateIfTooLong,
             };
 
-            var serializedMetric = serializer.Serialize(ref statsEvent, tags);
+            var serializedMetric = new SerializedMetric();
+            serializer.SerializeTo(ref statsEvent, tags, serializedMetric);
             Assert.AreEqual(expectValue, serializedMetric.ToString());
         }
 
         private static EventSerializer CreateSerializer()
         {
-            var serializerHelper = new SerializerHelper(null, 10);
+            var serializerHelper = new SerializerHelper(null);
             return new EventSerializer(serializerHelper);
         }
     }

--- a/tests/StatsdClient.Tests/Serializer/MetricSerializerTests.cs
+++ b/tests/StatsdClient.Tests/Serializer/MetricSerializerTests.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
+using StatsdClient.Statistic;
 
 namespace StatsdClient.Tests
 {
@@ -244,33 +246,32 @@ namespace StatsdClient.Tests
         [Test]
         public void SendSet()
         {
-            AssertSerialize("set:5|s", MetricType.Set, "set", 5);
+            AssertSetSerialize("set:5|s", "set", 5);
         }
 
         [Test]
         public void SendSetString()
         {
-            AssertSerialize("set:objectname|s", MetricType.Set, "set", "objectname");
+            AssertSetSerialize("set:objectname|s", "set", "objectname");
         }
 
         [Test]
         public void SendSetWithTags()
         {
-            AssertSerialize("set:5|s|#tag1:true,tag2", MetricType.Set, "set", 5, tags: new[] { "tag1:true", "tag2" });
+            AssertSetSerialize("set:5|s|#tag1:true,tag2", "set", 5, tags: new[] { "tag1:true", "tag2" });
         }
 
         [Test]
         public void SendSetWithSampleRate()
         {
-            AssertSerialize("set:5|s|@0.1", MetricType.Set, "set", 5, sampleRate: 0.1);
+            AssertSetSerialize("set:5|s|@0.1", "set", 5, sampleRate: 0.1);
         }
 
         [Test]
         public void SendSetWithSampleRateAndTags()
         {
-            AssertSerialize(
+            AssertSetSerialize(
                 "set:5|s|@0.1|#tag1:true,tag2",
-                MetricType.Set,
                 "set",
                 5,
                 sampleRate: 0.1,
@@ -280,32 +281,61 @@ namespace StatsdClient.Tests
         [Test]
         public void SendSetStringWithSampleRateAndTags()
         {
-            AssertSerialize(
+            AssertSetSerialize(
                 "set:objectname|s|@0.1|#tag1:true,tag2",
-                MetricType.Set,
                 "set",
                 "objectname",
                 sampleRate: 0.1,
                 tags: new[] { "tag1:true", "tag2" });
         }
 
-        private static void AssertSerialize<T>(
+        private static void AssertSerialize(
             string expectValue,
             MetricType metricType,
             string name,
-            T value,
+            double value,
             double sampleRate = 1.0,
             string[] tags = null,
             string prefix = null)
         {
+            var statsMetric = new StatsMetric
+            {
+                MetricType = metricType,
+                StatName = name,
+                SampleRate = sampleRate,
+                NumericValue = value,
+            };
+            AssertSerialize(expectValue, ref statsMetric, tags, prefix);
+        }
+
+        private static void AssertSetSerialize(
+           string expectValue,
+           string name,
+           object value,
+           double sampleRate = 1.0,
+           string[] tags = null,
+           string prefix = null)
+        {
+            var statsMetric = new StatsMetric
+            {
+                MetricType = MetricType.Set,
+                StatName = name,
+                SampleRate = sampleRate,
+                StringValue = value.ToString(),
+            };
+            AssertSerialize(expectValue, ref statsMetric, tags, prefix);
+        }
+
+        private static void AssertSerialize(
+           string expectValue,
+           ref StatsMetric statsMetric,
+           string[] tags,
+           string prefix)
+        {
             var serializerHelper = new SerializerHelper(null, 10);
             var serializer = new MetricSerializer(serializerHelper, prefix);
-            var serializedMetric = serializer.Serialize(
-                metricType,
-                name,
-                value,
-                sampleRate,
-                tags);
+
+            var serializedMetric = serializer.Serialize(ref statsMetric, tags);
             Assert.AreEqual(expectValue, serializedMetric.ToString());
         }
     }

--- a/tests/StatsdClient.Tests/Serializer/MetricSerializerTests.cs
+++ b/tests/StatsdClient.Tests/Serializer/MetricSerializerTests.cs
@@ -304,8 +304,9 @@ namespace StatsdClient.Tests
                 StatName = name,
                 SampleRate = sampleRate,
                 NumericValue = value,
+                Tags = tags,
             };
-            AssertSerialize(expectValue, ref statsMetric, tags, prefix);
+            AssertSerialize(expectValue, ref statsMetric, prefix);
         }
 
         private static void AssertSetSerialize(
@@ -322,20 +323,20 @@ namespace StatsdClient.Tests
                 StatName = name,
                 SampleRate = sampleRate,
                 StringValue = value.ToString(),
+                Tags = tags,
             };
-            AssertSerialize(expectValue, ref statsMetric, tags, prefix);
+            AssertSerialize(expectValue, ref statsMetric, prefix);
         }
 
         private static void AssertSerialize(
            string expectValue,
            ref StatsMetric statsMetric,
-           string[] tags,
            string prefix)
         {
             var serializerHelper = new SerializerHelper(null);
             var serializer = new MetricSerializer(serializerHelper, prefix);
             var serializedMetric = new SerializedMetric();
-            serializer.SerializeTo(ref statsMetric, tags, serializedMetric);
+            serializer.SerializeTo(ref statsMetric, serializedMetric);
             Assert.AreEqual(expectValue, serializedMetric.ToString());
         }
     }

--- a/tests/StatsdClient.Tests/Serializer/MetricSerializerTests.cs
+++ b/tests/StatsdClient.Tests/Serializer/MetricSerializerTests.cs
@@ -332,10 +332,10 @@ namespace StatsdClient.Tests
            string[] tags,
            string prefix)
         {
-            var serializerHelper = new SerializerHelper(null, 10);
+            var serializerHelper = new SerializerHelper(null);
             var serializer = new MetricSerializer(serializerHelper, prefix);
-
-            var serializedMetric = serializer.Serialize(ref statsMetric, tags);
+            var serializedMetric = new SerializedMetric();
+            serializer.SerializeTo(ref statsMetric, tags, serializedMetric);
             Assert.AreEqual(expectValue, serializedMetric.ToString());
         }
     }

--- a/tests/StatsdClient.Tests/Serializer/SerializerHelperTests.cs
+++ b/tests/StatsdClient.Tests/Serializer/SerializerHelperTests.cs
@@ -10,7 +10,7 @@ namespace Tests
         [Test]
         public void AppendTags()
         {
-            var helper = new SerializerHelper(null, 10);
+            var helper = new SerializerHelper(null);
             var builder = new StringBuilder();
 
             helper.AppendTags(builder, new string[0]);
@@ -23,7 +23,7 @@ namespace Tests
         [Test]
         public void AppendTagsWithConstantTags()
         {
-            var helper = new SerializerHelper(new[] { "ctag1", "ctag2" }, 10);
+            var helper = new SerializerHelper(new[] { "ctag1", "ctag2" });
             var builder = new StringBuilder();
 
             helper.AppendTags(builder, new string[0]);
@@ -50,21 +50,6 @@ namespace Tests
 
             SerializerHelper.AppendIfNotNull(builder, "prefix:", "value");
             Assert.AreEqual("prefix:value", builder.ToString());
-        }
-
-        [Test]
-        public void GetOptionalSerializedMetric()
-        {
-            var serializerHelper = new SerializerHelper(null, 10);
-
-            var metric = serializerHelper.GetOptionalSerializedMetric();
-            metric.Builder.Append("Test");
-            Assert.AreNotEqual(metric, serializerHelper.GetOptionalSerializedMetric());
-            metric.Dispose();
-
-            var recycledMetric = serializerHelper.GetOptionalSerializedMetric();
-            Assert.AreEqual(metric, recycledMetric);
-            Assert.AreEqual(0, recycledMetric.Builder.Length);
         }
     }
 }

--- a/tests/StatsdClient.Tests/Serializer/ServiceCheckSerializerTests.cs
+++ b/tests/StatsdClient.Tests/Serializer/ServiceCheckSerializerTests.cs
@@ -152,12 +152,14 @@ namespace StatsdClient.Tests
                 TruncateIfTooLong = truncateIfTooLong,
             };
             var serializer = CreateSerializer();
-            return serializer.Serialize(ref statsServiceCheck, tags);
+            var serializedMetric = new SerializedMetric();
+            serializer.SerializeTo(ref statsServiceCheck, tags, serializedMetric);
+            return serializedMetric;
         }
 
         private static ServiceCheckSerializer CreateSerializer()
         {
-            var serializerHelper = new SerializerHelper(null, 10);
+            var serializerHelper = new SerializerHelper(null);
             return new ServiceCheckSerializer(serializerHelper);
         }
     }

--- a/tests/StatsdClient.Tests/Serializer/ServiceCheckSerializerTests.cs
+++ b/tests/StatsdClient.Tests/Serializer/ServiceCheckSerializerTests.cs
@@ -150,10 +150,11 @@ namespace StatsdClient.Tests
                 Hostname = hostname,
                 ServiceCheckMessage = serviceCheckMessage,
                 TruncateIfTooLong = truncateIfTooLong,
+                Tags = tags,
             };
             var serializer = CreateSerializer();
             var serializedMetric = new SerializedMetric();
-            serializer.SerializeTo(ref statsServiceCheck, tags, serializedMetric);
+            serializer.SerializeTo(ref statsServiceCheck, serializedMetric);
             return serializedMetric;
         }
 

--- a/tests/StatsdClient.Tests/StatsdBuilderTests.cs
+++ b/tests/StatsdClient.Tests/StatsdBuilderTests.cs
@@ -124,10 +124,13 @@ namespace StatsdClient.Tests
 
             BuildStatsData(config);
             _mock.Verify(m => m.CreateStatsBufferize(
-                It.Is<BufferBuilder>(b => b.Capacity == config.StatsdMaxUDPPacketSize),
+                It.IsAny<StatsRouter>(),
                 conf.MaxMetricsInAsyncQueue,
                 conf.MaxBlockDuration,
                 conf.DurationBeforeSendingNotFullBuffer));
+            _mock.Verify(m => m.CreateStatsRouter(
+                It.IsAny<Serializers>(),
+                It.Is<BufferBuilder>(b => b.Capacity == config.StatsdMaxUDPPacketSize)));
         }
 
 #if !OS_WINDOWS
@@ -139,10 +142,13 @@ namespace StatsdClient.Tests
 
             BuildStatsData(config);
             _mock.Verify(m => m.CreateStatsBufferize(
-                It.Is<BufferBuilder>(b => b.Capacity == config.StatsdMaxUnixDomainSocketPacketSize),
+                It.IsAny<StatsRouter>(),
                 It.IsAny<int>(),
                 null,
                 It.IsAny<TimeSpan>()));
+            _mock.Verify(m => m.CreateStatsRouter(
+                It.IsAny<Serializers>(),
+                It.Is<BufferBuilder>(b => b.Capacity == config.StatsdMaxUnixDomainSocketPacketSize)));
         }
 #endif
 


### PR DESCRIPTION
This PR updates the current pipeline to prepare client side aggregation dev.

Before:
1 When calling `DogStatsdService.Increment`, the metric was serialized as a raw data (`byte[]`)
2 The raw data is sent to the concurrent queue. 
3 Another thread read the raw data from the queue and aggregated it into a buffer.
4 The buffer is sent

After:
1 When calling `DogStatsdService.Increment`, the metric is stored as a `Stats` instance
2 The `Stats` instance is sent to the concurrent queue. 
3 Another thread read the `Stats` instance, serialized it to raw data and aggregated into a buffer.
4 The buffer is sent

Implementation notes:
Generic was removed from DogStatsdService and so this PR introduces a breaking change in the API. Only custom type should be impacted.
All metrics are sent as a double. For performance reasons, `Counting` should also be sent as long. It is not yet done and I am going to work on it in another PR.