### PR TITLE
Client side aggregation

### DIFF
--- a/src/StatsdClient/Aggregator/AggregatorFlusher.cs
+++ b/src/StatsdClient/Aggregator/AggregatorFlusher.cs
@@ -23,7 +23,7 @@ namespace StatsdClient.Aggregator
         {
             _serializer = parameters.Serializer;
             _bufferBuilder = parameters.BufferBuilder;
-            _flushIntervalMilliseconds = (long)parameters.FlushInternal.TotalMilliseconds;
+            _flushIntervalMilliseconds = (long)parameters.FlushInterval.TotalMilliseconds;
             _maxUniqueStatsBeforeFlush = parameters.MaxUniqueStatsBeforeFlush;
             _expectedMetricType = expectedMetricType;
         }

--- a/src/StatsdClient/Aggregator/AggregatorFlusher.cs
+++ b/src/StatsdClient/Aggregator/AggregatorFlusher.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using StatsdClient.Bufferize;
+using StatsdClient.Statistic;
+
+namespace StatsdClient.Aggregator
+{
+    /// <summary>
+    /// AggregatorFlusher is responsible for flushing the aggregated `MetricStats` instances.
+    /// </summary>
+    internal class AggregatorFlusher<T>
+    {
+        private readonly MetricSerializer _serializer;
+        private readonly BufferBuilder _bufferBuilder;
+        private readonly Dictionary<MetricStatsKey, T> _values = new Dictionary<MetricStatsKey, T>();
+        private readonly System.Diagnostics.Stopwatch _stopWatch = System.Diagnostics.Stopwatch.StartNew();
+        private readonly int _maxUniqueStatsBeforeFlush;
+        private readonly long _flushIntervalMilliseconds;
+        private readonly SerializedMetric _serializedMetric = new SerializedMetric();
+        private readonly MetricType _expectedMetricType;
+
+        public AggregatorFlusher(MetricAggregatorParameters parameters, MetricType expectedMetricType)
+        {
+            _serializer = parameters.Serializer;
+            _bufferBuilder = parameters.BufferBuilder;
+            _flushIntervalMilliseconds = (long)parameters.FlushInternal.TotalMilliseconds;
+            _maxUniqueStatsBeforeFlush = parameters.MaxUniqueStatsBeforeFlush;
+            _expectedMetricType = expectedMetricType;
+        }
+
+        public bool TryGetValue(ref MetricStatsKey key, out T v)
+        {
+            return this._values.TryGetValue(key, out v);
+        }
+
+        public void Add(ref MetricStatsKey key, T v)
+        {
+            this._values.Add(key, v);
+        }
+
+        public void Update(ref MetricStatsKey key, T v)
+        {
+            this._values[key] = v;
+        }
+
+        public void TryFlush(Action<Dictionary<MetricStatsKey, T>> addSerializedMetric, bool force)
+        {
+            if (force
+            || _stopWatch.ElapsedMilliseconds > _flushIntervalMilliseconds
+            || _values.Count > _maxUniqueStatsBeforeFlush)
+            {
+                addSerializedMetric(_values);
+                _bufferBuilder.HandleBufferAndReset();
+                this._stopWatch.Restart();
+                _values.Clear();
+            }
+        }
+
+        public void FlushStatsMetric(StatsMetric metric)
+        {
+            _serializer.SerializeTo(ref metric, _serializedMetric);
+            _bufferBuilder.Add(_serializedMetric);
+        }
+
+        public MetricStatsKey CreateKey(StatsMetric metric)
+        {
+            if (metric.MetricType != _expectedMetricType)
+            {
+                throw new ArgumentException($"Metric type is {metric.MetricType} instead of {_expectedMetricType}.");
+            }
+
+            return new MetricStatsKey(metric.StatName, metric.Tags);
+        }
+    }
+}

--- a/src/StatsdClient/Aggregator/AggregatorFlusher.cs
+++ b/src/StatsdClient/Aggregator/AggregatorFlusher.cs
@@ -47,7 +47,7 @@ namespace StatsdClient.Aggregator
         {
             if (force
             || _stopWatch.ElapsedMilliseconds > _flushIntervalMilliseconds
-            || _values.Count > _maxUniqueStatsBeforeFlush)
+            || _values.Count >= _maxUniqueStatsBeforeFlush)
             {
                 addSerializedMetric(_values);
                 _bufferBuilder.HandleBufferAndReset();

--- a/src/StatsdClient/Aggregator/Aggregators.cs
+++ b/src/StatsdClient/Aggregator/Aggregators.cs
@@ -1,0 +1,14 @@
+namespace StatsdClient.Aggregator
+{
+    /// <summary>
+    /// Store all aggregators
+    /// </summary>
+    internal class Aggregators
+    {
+        public CountingAggregator OptionalCounting { get; set; }
+
+        public GaugeAggregator OptionalGauge { get; set; }
+
+        public SetAggregator OptionalSet { get; set; }
+    }
+}

--- a/src/StatsdClient/Aggregator/Aggregators.cs
+++ b/src/StatsdClient/Aggregator/Aggregators.cs
@@ -5,7 +5,7 @@ namespace StatsdClient.Aggregator
     /// </summary>
     internal class Aggregators
     {
-        public CountingAggregator OptionalCounting { get; set; }
+        public CountAggregator OptionalCount { get; set; }
 
         public GaugeAggregator OptionalGauge { get; set; }
 

--- a/src/StatsdClient/Aggregator/CountAggregator.cs
+++ b/src/StatsdClient/Aggregator/CountAggregator.cs
@@ -3,13 +3,14 @@ using StatsdClient.Statistic;
 namespace StatsdClient.Aggregator
 {
     /// <summary>
-    /// Aggregate `StatsMetric` instances of type `Counting` by summing the value by `MetricStatsKey`.
+    /// Aggregate <see cref="StatsMetric"/> instances of type <see cref="MetricType.Count"/>
+    /// by summing the value by <see cref="MetricStatsKey"/>.
     /// </summary>
-    internal class CountingAggregator
+    internal class CountAggregator
     {
         private readonly AggregatorFlusher<StatsMetric> _aggregator;
 
-        public CountingAggregator(MetricAggregatorParameters parameters)
+        public CountAggregator(MetricAggregatorParameters parameters)
         {
             _aggregator = new AggregatorFlusher<StatsMetric>(parameters, MetricType.Count);
         }

--- a/src/StatsdClient/Aggregator/CountingAggregator.cs
+++ b/src/StatsdClient/Aggregator/CountingAggregator.cs
@@ -1,0 +1,46 @@
+using StatsdClient.Statistic;
+
+namespace StatsdClient.Aggregator
+{
+    /// <summary>
+    /// Aggregate `StatsMetric` instances of type `Counting` by summing the value by `MetricStatsKey`.
+    /// </summary>
+    internal class CountingAggregator
+    {
+        private readonly AggregatorFlusher<StatsMetric> _aggregator;
+
+        public CountingAggregator(MetricAggregatorParameters parameters)
+        {
+            _aggregator = new AggregatorFlusher<StatsMetric>(parameters, MetricType.Counting);
+        }
+
+        public void OnNewValue(ref StatsMetric metric)
+        {
+            var key = _aggregator.CreateKey(metric);
+            if (_aggregator.TryGetValue(ref key, out var v))
+            {
+                v.NumericValue += metric.NumericValue;
+                _aggregator.Update(ref key, v);
+            }
+            else
+            {
+                _aggregator.Add(ref key, metric);
+            }
+
+            this.TryFlush();
+        }
+
+        public void TryFlush(bool force = false)
+        {
+            _aggregator.TryFlush(
+                values =>
+                {
+                    foreach (var keyValue in values)
+                    {
+                        _aggregator.FlushStatsMetric(keyValue.Value);
+                    }
+                },
+                force);
+        }
+    }
+}

--- a/src/StatsdClient/Aggregator/CountingAggregator.cs
+++ b/src/StatsdClient/Aggregator/CountingAggregator.cs
@@ -11,7 +11,7 @@ namespace StatsdClient.Aggregator
 
         public CountingAggregator(MetricAggregatorParameters parameters)
         {
-            _aggregator = new AggregatorFlusher<StatsMetric>(parameters, MetricType.Counting);
+            _aggregator = new AggregatorFlusher<StatsMetric>(parameters, MetricType.Count);
         }
 
         public void OnNewValue(ref StatsMetric metric)

--- a/src/StatsdClient/Aggregator/GaugeAggregator.cs
+++ b/src/StatsdClient/Aggregator/GaugeAggregator.cs
@@ -1,0 +1,45 @@
+using StatsdClient.Statistic;
+
+namespace StatsdClient.Aggregator
+{
+    /// <summary>
+    /// Aggregate `StatsMetric` instances of type `Gauge` by by keeping the last value.
+    /// </summary>
+    internal class GaugeAggregator
+    {
+        private readonly AggregatorFlusher<StatsMetric> _aggregator;
+
+        public GaugeAggregator(MetricAggregatorParameters parameters)
+        {
+            _aggregator = new AggregatorFlusher<StatsMetric>(parameters, MetricType.Gauge);
+        }
+
+        public void OnNewValue(ref StatsMetric metric)
+        {
+            var key = _aggregator.CreateKey(metric);
+            if (_aggregator.TryGetValue(ref key, out var _))
+            {
+                _aggregator.Update(ref key, metric);
+            }
+            else
+            {
+                _aggregator.Add(ref key, metric);
+            }
+
+            this.TryFlush();
+        }
+
+        public void TryFlush(bool force = false)
+        {
+            _aggregator.TryFlush(
+                values =>
+                {
+                    foreach (var keyValue in values)
+                    {
+                        _aggregator.FlushStatsMetric(keyValue.Value);
+                    }
+                },
+                force);
+        }
+    }
+}

--- a/src/StatsdClient/Aggregator/MetricAggregatorParameters.cs
+++ b/src/StatsdClient/Aggregator/MetricAggregatorParameters.cs
@@ -1,0 +1,28 @@
+using System;
+using StatsdClient.Bufferize;
+
+namespace StatsdClient.Aggregator
+{
+    internal class MetricAggregatorParameters
+    {
+        public MetricAggregatorParameters(
+            MetricSerializer serializer,
+            BufferBuilder bufferBuilder,
+            int maxUniqueStatsBeforeFlush,
+            TimeSpan flushInternal)
+        {
+            Serializer = serializer;
+            BufferBuilder = bufferBuilder;
+            MaxUniqueStatsBeforeFlush = maxUniqueStatsBeforeFlush;
+            FlushInternal = flushInternal;
+        }
+
+        public MetricSerializer Serializer { get; }
+
+        public BufferBuilder BufferBuilder { get; }
+
+        public int MaxUniqueStatsBeforeFlush { get; }
+
+        public TimeSpan FlushInternal { get; }
+    }
+}

--- a/src/StatsdClient/Aggregator/MetricAggregatorParameters.cs
+++ b/src/StatsdClient/Aggregator/MetricAggregatorParameters.cs
@@ -9,12 +9,12 @@ namespace StatsdClient.Aggregator
             MetricSerializer serializer,
             BufferBuilder bufferBuilder,
             int maxUniqueStatsBeforeFlush,
-            TimeSpan flushInternal)
+            TimeSpan flushInterval)
         {
             Serializer = serializer;
             BufferBuilder = bufferBuilder;
             MaxUniqueStatsBeforeFlush = maxUniqueStatsBeforeFlush;
-            FlushInternal = flushInternal;
+            FlushInterval = flushInterval;
         }
 
         public MetricSerializer Serializer { get; }
@@ -23,6 +23,6 @@ namespace StatsdClient.Aggregator
 
         public int MaxUniqueStatsBeforeFlush { get; }
 
-        public TimeSpan FlushInternal { get; }
+        public TimeSpan FlushInterval { get; }
     }
 }

--- a/src/StatsdClient/Aggregator/MetricStatsKey.cs
+++ b/src/StatsdClient/Aggregator/MetricStatsKey.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace StatsdClient.Aggregator
+{
+    /// <summary>
+    /// Dictionary Key for `MetricStats`.
+    /// It is more efficient to use `MetricStatsKey` than creating a string from metric name and tags.
+    /// </summary>
+    internal struct MetricStatsKey
+    {
+        private readonly string _metricName;
+        private readonly string[] _tags;
+
+        public MetricStatsKey(string metricName, string[] tags)
+        {
+            _metricName = metricName;
+            _tags = tags;
+        }
+
+        // This code was auto generated
+        public override bool Equals(object obj)
+        {
+            return obj is MetricStatsKey key &&
+                   _metricName == key._metricName &&
+                   EqualityComparer<string[]>.Default.Equals(_tags, key._tags);
+        }
+
+        // This code was auto generated
+        public override int GetHashCode()
+        {
+            int hashCode = -335110880;
+            hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(_metricName);
+            hashCode = (hashCode * -1521134295) + EqualityComparer<string[]>.Default.GetHashCode(_tags);
+            return hashCode;
+        }
+    }
+}

--- a/src/StatsdClient/Aggregator/SetAggregator.cs
+++ b/src/StatsdClient/Aggregator/SetAggregator.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using StatsdClient.Statistic;
+using StatsdClient.Utils;
+
+namespace StatsdClient.Aggregator
+{
+    /// <summary>
+    /// Aggregate `StatsMetric` instances of type `Set` by keeping the unique values.
+    /// </summary>
+    internal class SetAggregator
+    {
+        private readonly AggregatorFlusher<StatsMetricSet> _aggregator;
+        private readonly Pool<StatsMetricSet> _pool;
+        private readonly Telemetry _optionalTelemetry;
+
+        public SetAggregator(MetricAggregatorParameters parameters, Telemetry optionalTelemetry)
+        {
+            _aggregator = new AggregatorFlusher<StatsMetricSet>(parameters, MetricType.Set);
+            _pool = new Pool<StatsMetricSet>(pool => new StatsMetricSet(pool), 2 * parameters.MaxUniqueStatsBeforeFlush);
+            _optionalTelemetry = optionalTelemetry;
+        }
+
+        public void OnNewValue(ref StatsMetric metric)
+        {
+            string value = metric.StringValue;
+            var key = _aggregator.CreateKey(metric);
+            if (_aggregator.TryGetValue(ref key, out var v))
+            {
+                v.Values.Add(value);
+                _aggregator.Update(ref key, v);
+            }
+            else
+            {
+                if (_pool.TryDequeue(out var metricFieldsMetricSet))
+                {
+                    metricFieldsMetricSet.StatsMetric = metric;
+                    metricFieldsMetricSet.Values.Add(value);
+                    _aggregator.Add(ref key, metricFieldsMetricSet);
+                }
+                else
+                {
+                    _optionalTelemetry?.OnPacketsDroppedQueue();
+                }
+            }
+
+            this.TryFlush();
+        }
+
+        public void TryFlush(bool force = false)
+        {
+            _aggregator.TryFlush(
+                dictionary =>
+                {
+                    foreach (var keyValue in dictionary)
+                    {
+                        using (var statsMetricSet = keyValue.Value)
+                        {
+                            var metric = statsMetricSet.StatsMetric;
+                            foreach (var v in statsMetricSet.Values)
+                            {
+                                metric.StringValue = v;
+                                _aggregator.FlushStatsMetric(metric);
+                            }
+                        }
+                    }
+                },
+                force);
+        }
+
+        private class StatsMetricSet : AbstractPoolObject
+        {
+            public StatsMetricSet(IPool pool)
+            : base(pool)
+            {
+            }
+
+            public StatsMetric StatsMetric { get; set; }
+
+            public HashSet<string> Values { get; } = new HashSet<string>();
+
+            public override void Reset()
+            {
+                Values.Clear();
+            }
+        }
+    }
+}

--- a/src/StatsdClient/Aggregator/SetAggregator.cs
+++ b/src/StatsdClient/Aggregator/SetAggregator.cs
@@ -78,7 +78,7 @@ namespace StatsdClient.Aggregator
 
             public HashSet<string> Values { get; } = new HashSet<string>();
 
-            public override void Reset()
+            protected override void DoReset()
             {
                 Values.Clear();
             }

--- a/src/StatsdClient/Bufferize/BufferBuilder.cs
+++ b/src/StatsdClient/Bufferize/BufferBuilder.cs
@@ -38,20 +38,20 @@ namespace StatsdClient.Bufferize
             return _encoding.GetBytes(message);
         }
 
-        public bool Add(SerializedMetric serializedMetric)
+        public void Add(SerializedMetric serializedMetric)
         {
             var length = serializedMetric.CopyToChars(_charsBuffers);
 
             if (length < 0)
             {
-                return false;
+                throw new InvalidOperationException($"The metric size exceeds the internal buffer capacity {_charsBuffers.Length}: {serializedMetric.ToString()}");
             }
 
             var byteCount = _encoding.GetByteCount(_charsBuffers, 0, length);
 
             if (byteCount > Capacity)
             {
-                return false;
+                throw new InvalidOperationException($"The metric size exceeds the buffer capacity {Capacity}: {serializedMetric.ToString()}");
             }
 
             if (Length != 0)
@@ -72,7 +72,6 @@ namespace StatsdClient.Bufferize
 
             // GetBytes requires the buffer to be big enough otherwise it throws, that is why we use GetByteCount.
             Length += _encoding.GetBytes(_charsBuffers, 0, length, _buffer, Length);
-            return true;
         }
 
         public void HandleBufferAndReset()

--- a/src/StatsdClient/Bufferize/IStatsBufferizeFactory.cs
+++ b/src/StatsdClient/Bufferize/IStatsBufferizeFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using Mono.Unix;
+using StatsdClient.Aggregator;
 using StatsdClient.Transport;
 
 namespace StatsdClient.Bufferize
@@ -19,7 +20,8 @@ namespace StatsdClient.Bufferize
 
         StatsRouter CreateStatsRouter(
             Serializers serializers,
-            BufferBuilder bufferBuilder);
+            BufferBuilder bufferBuilder,
+            Aggregators optionalAggregators);
 
         ITransport CreateUDPTransport(IPEndPoint endPoint);
 

--- a/src/StatsdClient/Bufferize/StatsBufferize.cs
+++ b/src/StatsdClient/Bufferize/StatsBufferize.cs
@@ -75,7 +75,7 @@ namespace StatsdClient.Bufferize
 
                 if (_stopwatch.ElapsedMilliseconds > _maxIdleWaitBeforeSending.TotalMilliseconds)
                 {
-                    this._statsRouter.TryFlush();
+                    this._statsRouter.OnIdle();
 
                     return true;
                 }
@@ -85,7 +85,7 @@ namespace StatsdClient.Bufferize
 
             public void OnShutdown()
             {
-                this._statsRouter.TryFlush();
+                this._statsRouter.Flush();
             }
         }
     }

--- a/src/StatsdClient/Bufferize/StatsBufferizeFactory.cs
+++ b/src/StatsdClient/Bufferize/StatsBufferizeFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using Mono.Unix;
+using StatsdClient.Aggregator;
 using StatsdClient.Transport;
 
 namespace StatsdClient.Bufferize
@@ -22,9 +23,10 @@ namespace StatsdClient.Bufferize
 
         public StatsRouter CreateStatsRouter(
             Serializers serializers,
-            BufferBuilder bufferBuilder)
+            BufferBuilder bufferBuilder,
+            Aggregators optionalAggregators)
         {
-            return new StatsRouter(serializers, bufferBuilder);
+            return new StatsRouter(serializers, bufferBuilder, optionalAggregators);
         }
 
         public ITransport CreateUDPTransport(IPEndPoint endPoint)

--- a/src/StatsdClient/ClientSideAggregationConfig.cs
+++ b/src/StatsdClient/ClientSideAggregationConfig.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace StatsdClient
+{
+    /// <summary>
+    /// Define the configuration for the client side aggregation.
+    /// </summary>
+    public class ClientSideAggregationConfig
+    {
+        /// <summary>
+        /// Gets or sets the maximum number of unique stats before flushing.
+        /// </summary>
+        public int MaxUniqueStatsBeforeFlush { get; set; } = 10000;
+
+        /// <summary>
+        /// Gets or sets the maximum interval duration between two flushes.
+        /// </summary>
+        public TimeSpan FlushInternal { get; set; } = TimeSpan.FromSeconds(10);
+    }
+}

--- a/src/StatsdClient/ClientSideAggregationConfig.cs
+++ b/src/StatsdClient/ClientSideAggregationConfig.cs
@@ -15,6 +15,6 @@ namespace StatsdClient
         /// <summary>
         /// Gets or sets the maximum interval duration between two flushes.
         /// </summary>
-        public TimeSpan FlushInterval { get; set; } = TimeSpan.FromSeconds(10);
+        public TimeSpan FlushInterval { get; set; } = TimeSpan.FromSeconds(3);
     }
 }

--- a/src/StatsdClient/ClientSideAggregationConfig.cs
+++ b/src/StatsdClient/ClientSideAggregationConfig.cs
@@ -15,6 +15,6 @@ namespace StatsdClient
         /// <summary>
         /// Gets or sets the maximum interval duration between two flushes.
         /// </summary>
-        public TimeSpan FlushInternal { get; set; } = TimeSpan.FromSeconds(10);
+        public TimeSpan FlushInterval { get; set; } = TimeSpan.FromSeconds(10);
     }
 }

--- a/src/StatsdClient/Statistic/Stats.cs
+++ b/src/StatsdClient/Statistic/Stats.cs
@@ -28,7 +28,7 @@ namespace StatsdClient.Statistic
 
         public StatsKind Kind { get; set; }
 
-        public override void Reset()
+        protected override void DoReset()
         {
             // Nothing
         }

--- a/src/StatsdClient/StatsRouter.cs
+++ b/src/StatsdClient/StatsRouter.cs
@@ -7,7 +7,7 @@ namespace StatsdClient
 {
     /// <summary>
     /// Route `Stats` instances.
-    /// Route a metric of type <see cref="MetricType.Counting"/>, <see cref="MetricType.Gauge"/>
+    /// Route a metric of type <see cref="MetricType.Count"/>, <see cref="MetricType.Gauge"/>
     /// and <see cref="MetricType.Set"/> respectively to <see cref="CountingAggregator"/>,
     /// <see cref="GaugeAggregator"/> and <see cref="SetAggregator"/>.
     /// Others stats are routed to <see cref="BufferBuilder"/>.
@@ -83,7 +83,7 @@ namespace StatsdClient
         {
             switch (metric.MetricType)
             {
-                case MetricType.Counting:
+                case MetricType.Count:
                     if (_optionalCountingAggregator != null)
                     {
                         _optionalCountingAggregator.OnNewValue(ref metric);

--- a/src/StatsdClient/StatsRouter.cs
+++ b/src/StatsdClient/StatsRouter.cs
@@ -8,7 +8,7 @@ namespace StatsdClient
     /// <summary>
     /// Route `Stats` instances.
     /// Route a metric of type <see cref="MetricType.Count"/>, <see cref="MetricType.Gauge"/>
-    /// and <see cref="MetricType.Set"/> respectively to <see cref="CountingAggregator"/>,
+    /// and <see cref="MetricType.Set"/> respectively to <see cref="CountAggregator"/>,
     /// <see cref="GaugeAggregator"/> and <see cref="SetAggregator"/>.
     /// Others stats are routed to <see cref="BufferBuilder"/>.
     /// </summary>
@@ -16,7 +16,7 @@ namespace StatsdClient
     {
         private readonly Serializers _serializers;
         private readonly BufferBuilder _bufferBuilder;
-        private readonly CountingAggregator _optionalCountingAggregator;
+        private readonly CountAggregator _optionalCountAggregator;
         private readonly GaugeAggregator _optionalGaugeAggregator;
         private readonly SetAggregator _optionalSetAggregator;
 
@@ -31,7 +31,7 @@ namespace StatsdClient
             _bufferBuilder = bufferBuilder;
             if (optionalAggregators != null)
             {
-                _optionalCountingAggregator = optionalAggregators.OptionalCounting;
+                _optionalCountAggregator = optionalAggregators.OptionalCount;
                 _optionalGaugeAggregator = optionalAggregators.OptionalGauge;
                 _optionalSetAggregator = optionalAggregators.OptionalSet;
             }
@@ -74,7 +74,7 @@ namespace StatsdClient
         private void TryFlush(bool force)
         {
             _bufferBuilder.HandleBufferAndReset();
-            _optionalCountingAggregator?.TryFlush(force);
+            _optionalCountAggregator?.TryFlush(force);
             _optionalGaugeAggregator?.TryFlush(force);
             _optionalSetAggregator?.TryFlush(force);
         }
@@ -84,9 +84,9 @@ namespace StatsdClient
             switch (metric.MetricType)
             {
                 case MetricType.Count:
-                    if (_optionalCountingAggregator != null)
+                    if (_optionalCountAggregator != null)
                     {
-                        _optionalCountingAggregator.OnNewValue(ref metric);
+                        _optionalCountAggregator.OnNewValue(ref metric);
                         return false;
                     }
 

--- a/src/StatsdClient/StatsRouter.cs
+++ b/src/StatsdClient/StatsRouter.cs
@@ -58,10 +58,7 @@ namespace StatsdClient
                     throw new ArgumentException($"{stats.Kind} is not supported");
             }
 
-            if (!_bufferBuilder.Add(_serializedMetric))
-            {
-                throw new InvalidOperationException($"The metric size exceeds the buffer capacity: {_serializedMetric.ToString()}");
-            }
+            _bufferBuilder.Add(_serializedMetric);
         }
 
         public void OnIdle()

--- a/src/StatsdClient/StatsdBuilder.cs
+++ b/src/StatsdClient/StatsdBuilder.cs
@@ -216,7 +216,7 @@ namespace StatsdClient
                     serializers.MetricSerializer,
                     bufferBuilder,
                     optionalClientSideAggregationConfig.MaxUniqueStatsBeforeFlush,
-                    optionalClientSideAggregationConfig.FlushInternal);
+                    optionalClientSideAggregationConfig.FlushInterval);
 
                 optionalAggregators = new Aggregators
                 {

--- a/src/StatsdClient/StatsdBuilder.cs
+++ b/src/StatsdClient/StatsdBuilder.cs
@@ -220,7 +220,7 @@ namespace StatsdClient
 
                 optionalAggregators = new Aggregators
                 {
-                    OptionalCounting = new CountingAggregator(parameters),
+                    OptionalCount = new CountAggregator(parameters),
                     OptionalGauge = new GaugeAggregator(parameters),
                     OptionalSet = new SetAggregator(parameters, telemetry),
                 };

--- a/src/StatsdClient/StatsdConfig.cs
+++ b/src/StatsdClient/StatsdConfig.cs
@@ -116,5 +116,11 @@ namespace StatsdClient
         /// </summary>
         /// <value>The global tags to be applied to every metric, event, and service check.</value>
         public string[] ConstantTags { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value defining the client side aggregation config.
+        /// If the value is null, the client side aggregation is not enabled.
+        /// </summary>
+        public ClientSideAggregationConfig ClientSideAggregation { get; set; }
     }
 }

--- a/tests/StatsdClient.Tests/Aggregator/AggregatorFlusherTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/AggregatorFlusherTests.cs
@@ -40,7 +40,7 @@ namespace StatsdClient.Tests.Aggregator
         }
 
         [Test]
-        public void TryFlushFlushInternal()
+        public void TryFlushFlushInterval()
         {
             var handler = new Mock<IBufferBuilderHandler>();
             var parameters = MetricAggregatorParametersFactory.Create(

--- a/tests/StatsdClient.Tests/Aggregator/AggregatorFlusherTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/AggregatorFlusherTests.cs
@@ -20,7 +20,7 @@ namespace StatsdClient.Tests.Aggregator
                 TimeSpan.FromMinutes(1),
                 maxUniqueStatsBeforeFlush: 3);
 
-            var aggregator = new AggregatorFlusher<StatsMetric>(parameters, MetricType.Counting);
+            var aggregator = new AggregatorFlusher<StatsMetric>(parameters, MetricType.Count);
             Add(aggregator, "key1", new StatsMetric { });
             Add(aggregator, "key2", new StatsMetric { });
             Flush(aggregator);
@@ -48,7 +48,7 @@ namespace StatsdClient.Tests.Aggregator
                 TimeSpan.FromMilliseconds(500),
                 maxUniqueStatsBeforeFlush: 100);
 
-            var aggregator = new AggregatorFlusher<StatsMetric>(parameters, MetricType.Counting);
+            var aggregator = new AggregatorFlusher<StatsMetric>(parameters, MetricType.Count);
             Add(aggregator, "key", new StatsMetric { });
             Flush(aggregator);
             handler.Verify(h => h.Handle(It.IsAny<byte[]>(), It.IsAny<int>()), Times.Never());

--- a/tests/StatsdClient.Tests/Aggregator/AggregatorFlusherTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/AggregatorFlusherTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Threading;
+using Moq;
+using NUnit.Framework;
+using StatsdClient.Aggregator;
+using StatsdClient.Bufferize;
+using StatsdClient.Statistic;
+
+namespace StatsdClient.Tests.Aggregator
+{
+    [TestFixture]
+    public class AggregatorFlusherTests
+    {
+        [Test]
+        public void TryFlushMaxUniqueStatsBeforeFlush()
+        {
+            var handler = new Mock<IBufferBuilderHandler>();
+            var parameters = MetricAggregatorParametersFactory.Create(
+                handler.Object,
+                TimeSpan.FromMinutes(1),
+                maxUniqueStatsBeforeFlush: 2);
+
+            var aggregator = new AggregatorFlusher<StatsMetric>(parameters, MetricType.Counting);
+            Add(aggregator, "key1", new StatsMetric { });
+            Add(aggregator, "key2", new StatsMetric { });
+            Flush(aggregator);
+
+            handler.Verify(h => h.Handle(It.IsAny<byte[]>(), It.IsAny<int>()), Times.Never());
+
+            Add(aggregator, "key3", new StatsMetric { });
+            Flush(aggregator);
+            handler.Verify(h => h.Handle(It.IsAny<byte[]>(), It.IsAny<int>()), Times.Once());
+
+            Add(aggregator, "key4", new StatsMetric { });
+            Flush(aggregator);
+            handler.Verify(h => h.Handle(It.IsAny<byte[]>(), It.IsAny<int>()), Times.Once());
+
+            Flush(aggregator, force: true);
+            handler.Verify(h => h.Handle(It.IsAny<byte[]>(), It.IsAny<int>()), Times.Exactly(2));
+        }
+
+        [Test]
+        public void TryFlushFlushInternal()
+        {
+            var handler = new Mock<IBufferBuilderHandler>();
+            var parameters = MetricAggregatorParametersFactory.Create(
+                handler.Object,
+                TimeSpan.FromMilliseconds(500),
+                maxUniqueStatsBeforeFlush: 100);
+
+            var aggregator = new AggregatorFlusher<StatsMetric>(parameters, MetricType.Counting);
+            Add(aggregator, "key", new StatsMetric { });
+            Flush(aggregator);
+            handler.Verify(h => h.Handle(It.IsAny<byte[]>(), It.IsAny<int>()), Times.Never());
+
+            Thread.Sleep(TimeSpan.FromSeconds(1));
+            Flush(aggregator);
+            handler.Verify(h => h.Handle(It.IsAny<byte[]>(), It.IsAny<int>()), Times.Once());
+        }
+
+        private static void Add(AggregatorFlusher<StatsMetric> aggregator, string key, StatsMetric value)
+        {
+            var statsKey = new MetricStatsKey(key, null);
+            aggregator.Add(ref statsKey, value);
+        }
+
+        private static void Flush(AggregatorFlusher<StatsMetric> aggregator, bool force = false)
+        {
+            aggregator.TryFlush(
+                values =>
+            {
+                foreach (var keyValue in values)
+                {
+                    aggregator.FlushStatsMetric(keyValue.Value);
+                }
+            }, force);
+        }
+    }
+}

--- a/tests/StatsdClient.Tests/Aggregator/AggregatorFlusherTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/AggregatorFlusherTests.cs
@@ -18,7 +18,7 @@ namespace StatsdClient.Tests.Aggregator
             var parameters = MetricAggregatorParametersFactory.Create(
                 handler.Object,
                 TimeSpan.FromMinutes(1),
-                maxUniqueStatsBeforeFlush: 2);
+                maxUniqueStatsBeforeFlush: 3);
 
             var aggregator = new AggregatorFlusher<StatsMetric>(parameters, MetricType.Counting);
             Add(aggregator, "key1", new StatsMetric { });

--- a/tests/StatsdClient.Tests/Aggregator/BufferBuilderHandlerMock.cs
+++ b/tests/StatsdClient.Tests/Aggregator/BufferBuilderHandlerMock.cs
@@ -1,0 +1,26 @@
+using System.Text;
+using Moq;
+using StatsdClient.Bufferize;
+
+namespace StatsdClient.Tests.Aggregator
+{
+    /// <summary>
+    /// Mock for `IBufferBuilderHandler`.
+    /// </summary>
+    internal class BufferBuilderHandlerMock
+    {
+        private readonly Mock<IBufferBuilderHandler> _handler = new Mock<IBufferBuilderHandler>();
+
+        public BufferBuilderHandlerMock()
+        {
+            _handler.Setup(h => h.Handle(It.IsAny<byte[]>(), It.IsAny<int>())).Callback<byte[], int>((buffer, len) =>
+            {
+                Value = Encoding.UTF8.GetString(buffer, 0, len);
+            });
+        }
+
+        public string Value { get; private set; }
+
+        public IBufferBuilderHandler Object => _handler.Object;
+    }
+}

--- a/tests/StatsdClient.Tests/Aggregator/CountAggregatorTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/CountAggregatorTests.cs
@@ -5,13 +5,13 @@ using StatsdClient.Statistic;
 namespace StatsdClient.Tests.Aggregator
 {
     [TestFixture]
-    public class CountingAggregatorTests
+    public class CountAggregatorTests
     {
         [Test]
         public void OnNewValue()
         {
             var handler = new BufferBuilderHandlerMock();
-            var aggregator = new CountingAggregator(MetricAggregatorParametersFactory.Create(handler.Object));
+            var aggregator = new CountAggregator(MetricAggregatorParametersFactory.Create(handler.Object));
             AddStatsMetric(aggregator, "s1", 1);
             AddStatsMetric(aggregator, "s1", 2);
             AddStatsMetric(aggregator, "s2", 2);
@@ -23,11 +23,12 @@ namespace StatsdClient.Tests.Aggregator
             Assert.AreEqual("s3:1|c|@0", handler.Value);
         }
 
-        private static void AddStatsMetric(CountingAggregator aggregator, string statName, double value)
+        private static void AddStatsMetric(CountAggregator aggregator, string statName, double value)
         {
             var statsMetric = new StatsMetric
             {
-                MetricType = MetricType.Count,
+                MetricType = MetricType.
+                Count,
                 StatName = statName,
                 NumericValue = value,
             };

--- a/tests/StatsdClient.Tests/Aggregator/CountingAggregatorTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/CountingAggregatorTests.cs
@@ -1,0 +1,38 @@
+using NUnit.Framework;
+using StatsdClient.Aggregator;
+using StatsdClient.Statistic;
+
+namespace StatsdClient.Tests.Aggregator
+{
+    [TestFixture]
+    public class CountingAggregatorTests
+    {
+        [Test]
+        public void OnNewValue()
+        {
+            var handler = new BufferBuilderHandlerMock();
+            var aggregator = new CountingAggregator(MetricAggregatorParametersFactory.Create(handler.Object));
+            AddStatsMetric(aggregator, "s1", 1);
+            AddStatsMetric(aggregator, "s1", 2);
+            AddStatsMetric(aggregator, "s2", 2);
+            aggregator.TryFlush(force: true);
+            Assert.AreEqual("s1:3|c|@0,s2:2|c|@0", handler.Value);
+
+            AddStatsMetric(aggregator, "s3", 1);
+            aggregator.TryFlush(force: true);
+            Assert.AreEqual("s3:1|c|@0", handler.Value);
+        }
+
+        private static void AddStatsMetric(CountingAggregator aggregator, string statName, double value)
+        {
+            var statsMetric = new StatsMetric
+            {
+                MetricType = MetricType.Counting,
+                StatName = statName,
+                NumericValue = value,
+            };
+
+            aggregator.OnNewValue(ref statsMetric);
+        }
+    }
+}

--- a/tests/StatsdClient.Tests/Aggregator/CountingAggregatorTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/CountingAggregatorTests.cs
@@ -27,7 +27,7 @@ namespace StatsdClient.Tests.Aggregator
         {
             var statsMetric = new StatsMetric
             {
-                MetricType = MetricType.Counting,
+                MetricType = MetricType.Count,
                 StatName = statName,
                 NumericValue = value,
             };

--- a/tests/StatsdClient.Tests/Aggregator/GaugeAggregatorTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/GaugeAggregatorTests.cs
@@ -1,0 +1,35 @@
+using NUnit.Framework;
+using StatsdClient.Aggregator;
+using StatsdClient.Statistic;
+
+namespace StatsdClient.Tests.Aggregator
+{
+    [TestFixture]
+    public class GaugeAggregatorTests
+    {
+        [Test]
+        public void OnNewValue()
+        {
+            var handler = new BufferBuilderHandlerMock();
+            var aggregator = new GaugeAggregator(MetricAggregatorParametersFactory.Create(handler.Object));
+            AddStatsMetric(aggregator, "s1", 1);
+            AddStatsMetric(aggregator, "s1", 2);
+            AddStatsMetric(aggregator, "s2", 3);
+            aggregator.TryFlush(force: true);
+
+            Assert.AreEqual("s1:2|g|@0,s2:3|g|@0", handler.Value);
+        }
+
+        private static void AddStatsMetric(GaugeAggregator aggregator, string statName, double value)
+        {
+            var statsMetric = new StatsMetric
+            {
+                MetricType = MetricType.Gauge,
+                StatName = statName,
+                NumericValue = value,
+            };
+
+            aggregator.OnNewValue(ref statsMetric);
+        }
+    }
+}

--- a/tests/StatsdClient.Tests/Aggregator/MetricAggregatorParametersFactory.cs
+++ b/tests/StatsdClient.Tests/Aggregator/MetricAggregatorParametersFactory.cs
@@ -16,7 +16,7 @@ namespace StatsdClient.Tests.Aggregator
 
         public static MetricAggregatorParameters Create(
             IBufferBuilderHandler handler,
-            TimeSpan flushInternal,
+            TimeSpan flushInterval,
             int maxUniqueStatsBeforeFlush)
         {
             var serializer = new MetricSerializer(new SerializerHelper(null), string.Empty);
@@ -26,7 +26,7 @@ namespace StatsdClient.Tests.Aggregator
                 serializer,
                 bufferBuilder,
                 maxUniqueStatsBeforeFlush,
-                flushInternal);
+                flushInterval);
         }
     }
 }

--- a/tests/StatsdClient.Tests/Aggregator/MetricAggregatorParametersFactory.cs
+++ b/tests/StatsdClient.Tests/Aggregator/MetricAggregatorParametersFactory.cs
@@ -1,0 +1,32 @@
+using System;
+using StatsdClient.Aggregator;
+using StatsdClient.Bufferize;
+
+namespace StatsdClient.Tests.Aggregator
+{
+    /// <summary>
+    /// Create an instance of `MetricAggregatorParameters` for the tests.
+    /// </summary>
+    internal static class MetricAggregatorParametersFactory
+    {
+        public static MetricAggregatorParameters Create(IBufferBuilderHandler handler)
+        {
+            return Create(handler, TimeSpan.FromMinutes(1), 1000);
+        }
+
+        public static MetricAggregatorParameters Create(
+            IBufferBuilderHandler handler,
+            TimeSpan flushInternal,
+            int maxUniqueStatsBeforeFlush)
+        {
+            var serializer = new MetricSerializer(new SerializerHelper(null), string.Empty);
+            var bufferBuilder = new BufferBuilder(handler, bufferCapacity: 1000, ",");
+
+            return new MetricAggregatorParameters(
+                serializer,
+                bufferBuilder,
+                maxUniqueStatsBeforeFlush,
+                flushInternal);
+        }
+    }
+}

--- a/tests/StatsdClient.Tests/Aggregator/SetAggregatorTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/SetAggregatorTests.cs
@@ -1,0 +1,56 @@
+using System;
+using NUnit.Framework;
+using StatsdClient.Aggregator;
+using StatsdClient.Statistic;
+
+namespace StatsdClient.Tests.Aggregator
+{
+    [TestFixture]
+    public class SetAggregatorTests
+    {
+        [Test]
+        public void OnNewValue()
+        {
+            var handler = new BufferBuilderHandlerMock();
+            var aggregator = new SetAggregator(MetricAggregatorParametersFactory.Create(handler.Object), null);
+            AddStatsMetric(aggregator, "s1", "1");
+            AddStatsMetric(aggregator, "s1", "2");
+            AddStatsMetric(aggregator, "s1", "2");
+            AddStatsMetric(aggregator, "s1", "2");
+            AddStatsMetric(aggregator, "s2", "3");
+            aggregator.TryFlush(force: true);
+            Assert.AreEqual("s1:1|s|@0,s1:2|s|@0,s2:3|s|@0", handler.Value);
+
+            AddStatsMetric(aggregator, "s1", "4");
+            aggregator.TryFlush(force: true);
+            Assert.AreEqual("s1:4|s|@0", handler.Value);
+        }
+
+        [Test]
+        public void Pool()
+        {
+            var handler = new BufferBuilderHandlerMock();
+            var parameters = MetricAggregatorParametersFactory.Create(handler.Object, TimeSpan.FromMinutes(1), 1);
+            var aggregator = new SetAggregator(parameters, null);
+
+            // Check StatsMetricSet instance go back to the pool
+            for (int i = 0; i < 10; ++i)
+            {
+                AddStatsMetric(aggregator, "s1", i.ToString());
+                Assert.AreEqual($"s1:{i}|s|@0", handler.Value);
+            }
+        }
+
+        private static void AddStatsMetric(SetAggregator aggregator, string statName, string value)
+        {
+            var statsMetric = new StatsMetric
+            {
+                MetricType = MetricType.Set,
+                StatName = statName,
+                StringValue = value,
+            };
+
+            aggregator.OnNewValue(ref statsMetric);
+        }
+    }
+}

--- a/tests/StatsdClient.Tests/Bufferize/BufferBuilderTests.cs
+++ b/tests/StatsdClient.Tests/Bufferize/BufferBuilderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using NUnit.Framework;
 using StatsdClient;
@@ -23,11 +24,11 @@ namespace Tests
         public void Add()
         {
             Assert.AreEqual(12, _bufferBuilder.Capacity);
-            Assert.True(_bufferBuilder.Add(CreateSerializedMetric('1', 3)));
-            Assert.True(_bufferBuilder.Add(CreateSerializedMetric('2', 3)));
-            Assert.True(_bufferBuilder.Add(CreateSerializedMetric('3', 3)));
+            _bufferBuilder.Add(CreateSerializedMetric('1', 3));
+            _bufferBuilder.Add(CreateSerializedMetric('2', 3));
+            _bufferBuilder.Add(CreateSerializedMetric('3', 3));
             Assert.Null(_handler.Buffer);
-            Assert.True(_bufferBuilder.Add(CreateSerializedMetric('4', 3)));
+            _bufferBuilder.Add(CreateSerializedMetric('4', 3));
             Assert.AreEqual(3, _bufferBuilder.Length);
             Assert.AreEqual(_handler.Buffer, Encoding.UTF8.GetBytes("111\n222\n333"));
         }
@@ -36,11 +37,11 @@ namespace Tests
         public void HandleBufferAndReset()
         {
             Assert.Less(4, _bufferBuilder.Capacity);
-            Assert.True(_bufferBuilder.Add(CreateSerializedMetric('1', 2)));
+            _bufferBuilder.Add(CreateSerializedMetric('1', 2));
             _bufferBuilder.HandleBufferAndReset();
             Assert.AreEqual(_handler.Buffer, Encoding.UTF8.GetBytes("11"));
 
-            Assert.True(_bufferBuilder.Add(CreateSerializedMetric('3', 4)));
+            _bufferBuilder.Add(CreateSerializedMetric('3', 4));
             _bufferBuilder.HandleBufferAndReset();
             Assert.AreEqual(_handler.Buffer, Encoding.UTF8.GetBytes("3333"));
         }
@@ -48,10 +49,10 @@ namespace Tests
         [Test]
         public void AddReturnedValue()
         {
-            Assert.False(_bufferBuilder.Add(CreateSerializedMetric('1', _bufferBuilder.Capacity + 1)));
+            Assert.Throws<InvalidOperationException>(() => _bufferBuilder.Add(CreateSerializedMetric('1', _bufferBuilder.Capacity + 1)));
             Assert.AreEqual(0, _bufferBuilder.Length);
 
-            Assert.True(_bufferBuilder.Add(CreateSerializedMetric('1', _bufferBuilder.Capacity)));
+            _bufferBuilder.Add(CreateSerializedMetric('1', _bufferBuilder.Capacity));
             Assert.AreEqual(_bufferBuilder.Capacity, _bufferBuilder.Length);
         }
 

--- a/tests/StatsdClient.Tests/Bufferize/StatsBufferizeTests.cs
+++ b/tests/StatsdClient.Tests/Bufferize/StatsBufferizeTests.cs
@@ -23,7 +23,7 @@ namespace Tests
             {
                 EventSerializer = new EventSerializer(new SerializerHelper(null)),
             };
-            var statsRouter = new StatsRouter(serializers, bufferBuilder);
+            var statsRouter = new StatsRouter(serializers, bufferBuilder, null);
             using (var statsBufferize = new StatsBufferize(statsRouter, 10, null, TimeSpan.Zero))
             {
                 var pool = new Pool<Stats>(p => new Stats(p), 1);

--- a/tests/StatsdClient.Tests/StatsdBuilderTests.cs
+++ b/tests/StatsdClient.Tests/StatsdBuilderTests.cs
@@ -5,6 +5,7 @@ using System.Net;
 using Mono.Unix;
 using Moq;
 using NUnit.Framework;
+using StatsdClient.Aggregator;
 using StatsdClient.Bufferize;
 using StatsdClient.Transport;
 
@@ -128,9 +129,11 @@ namespace StatsdClient.Tests
                 conf.MaxMetricsInAsyncQueue,
                 conf.MaxBlockDuration,
                 conf.DurationBeforeSendingNotFullBuffer));
-            _mock.Verify(m => m.CreateStatsRouter(
+            _mock.Verify(
+                m => m.CreateStatsRouter(
                 It.IsAny<Serializers>(),
-                It.Is<BufferBuilder>(b => b.Capacity == config.StatsdMaxUDPPacketSize)));
+                It.Is<BufferBuilder>(b => b.Capacity == config.StatsdMaxUDPPacketSize),
+                It.IsAny<Aggregators>()));
         }
 
 #if !OS_WINDOWS
@@ -146,9 +149,11 @@ namespace StatsdClient.Tests
                 It.IsAny<int>(),
                 null,
                 It.IsAny<TimeSpan>()));
-            _mock.Verify(m => m.CreateStatsRouter(
+            _mock.Verify(
+                m => m.CreateStatsRouter(
                 It.IsAny<Serializers>(),
-                It.Is<BufferBuilder>(b => b.Capacity == config.StatsdMaxUnixDomainSocketPacketSize)));
+                It.Is<BufferBuilder>(b => b.Capacity == config.StatsdMaxUnixDomainSocketPacketSize),
+                It.IsAny<Aggregators>()));
         }
 #endif
 

--- a/tests/StatsdClient.Tests/StatsdBuilderTests.cs
+++ b/tests/StatsdClient.Tests/StatsdBuilderTests.cs
@@ -191,6 +191,27 @@ namespace StatsdClient.Tests
             _mock.Verify(m => m.CreateUDPTransport(It.IsAny<IPEndPoint>()), Times.Exactly(2));
         }
 
+        [Test]
+        public void ClientSideAggregation()
+        {
+            var config = new StatsdConfig { };
+
+            BuildStatsData(config);
+            _mock.Verify(
+                m => m.CreateStatsRouter(
+                It.IsAny<Serializers>(),
+                It.Is<BufferBuilder>(b => b.Capacity == config.StatsdMaxUDPPacketSize),
+                null));
+
+            config.ClientSideAggregation = new ClientSideAggregationConfig();
+            BuildStatsData(config);
+            _mock.Verify(
+                m => m.CreateStatsRouter(
+                It.IsAny<Serializers>(),
+                It.Is<BufferBuilder>(b => b.Capacity == config.StatsdMaxUDPPacketSize),
+                It.IsNotNull<Aggregators>()));
+        }
+
         private static StatsdConfig CreateUDSConfig(string server = null)
         {
             var config = new StatsdConfig();


### PR DESCRIPTION
Add the client side aggregation to improve the performance:
- For `Count`: sum the value for same metric names and tags
- For `Gauge`: Keep the last value for same metric names and tags
- For `Set`: Keep unique value for for same metric names and tags