### PR TITLE
Work around 64 bit RyuJIT ThreadAbortException bug on the .NET Framework

### DIFF
--- a/src/StatsdClient/Worker/AsynchronousWorker.cs
+++ b/src/StatsdClient/Worker/AsynchronousWorker.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace StatsdClient.Worker
@@ -111,6 +112,15 @@ namespace StatsdClient.Worker
                         }
                     }
                 }
+#if !NETSTANDARD1_3
+                catch (ThreadAbortException e)
+                {
+                    Debug.WriteLine(e.Message);
+                    // This is the defined behavior of a ThreadAbortException, but it doesn't happen on
+                    // the .NET Framework in 64-bit release builds using RyuJIT
+                    throw;
+                }
+#endif
                 catch (Exception e)
                 {
                     Debug.WriteLine(e.Message);

--- a/src/StatsdClient/Worker/AsynchronousWorker.cs
+++ b/src/StatsdClient/Worker/AsynchronousWorker.cs
@@ -112,7 +112,7 @@ namespace StatsdClient.Worker
                         }
                     }
                 }
-#if !NETSTANDARD1_3
+#if NETFRAMEWORK
                 catch (ThreadAbortException e)
                 {
                     Debug.WriteLine(e.Message);

--- a/tests/StatsdClient.Tests/StatsdClient.Tests.csproj
+++ b/tests/StatsdClient.Tests/StatsdClient.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>StatsdClient.snk</AssemblyOriginatorKeyFile>
     <NoWarn>0618</NoWarn>

--- a/tests/StatsdClient.Tests/TelemetryTests.cs
+++ b/tests/StatsdClient.Tests/TelemetryTests.cs
@@ -113,8 +113,8 @@ namespace Tests
             _telemetry.Flush();
             foreach (var m in _metrics)
             {
-                var nameWithoutTags = m.Split("|")[0];
-                var part = nameWithoutTags.Split(":");
+                var nameWithoutTags = m.Split('|')[0];
+                var part = nameWithoutTags.Split(':');
                 var metricName = part[0];
                 var metricValue = int.Parse(part[1]);
 

--- a/tests/StatsdClient.Tests/Worker/AsynchronousWorkerTests.cs
+++ b/tests/StatsdClient.Tests/Worker/AsynchronousWorkerTests.cs
@@ -98,7 +98,21 @@ namespace Tests
 
             Assert.DoesNotThrow(() => AppDomain.Unload(domain));
         }
+#endif
 
+        private AsynchronousWorker<int> CreateWorker(int workerThreadCount = 2)
+        {
+            var worker = new AsynchronousWorker<int>(
+                _handler.Object,
+                _waiter.Object,
+                workerThreadCount,
+                10,
+                null);
+            _workers.Add(worker);
+            return worker;
+        }
+
+#if NETFRAMEWORK
         private class AppDomainDelegate : MarshalByRefObject
         {
             public void Execute()
@@ -114,17 +128,5 @@ namespace Tests
             }
         }
 #endif
-
-        private AsynchronousWorker<int> CreateWorker(int workerThreadCount = 2)
-        {
-            var worker = new AsynchronousWorker<int>(
-                _handler.Object,
-                _waiter.Object,
-                workerThreadCount,
-                10,
-                null);
-            _workers.Add(worker);
-            return worker;
-        }
     }
 }

--- a/tests/StatsdClient.Tests/Worker/AsynchronousWorkerTests.cs
+++ b/tests/StatsdClient.Tests/Worker/AsynchronousWorkerTests.cs
@@ -81,6 +81,40 @@ namespace Tests
             worker.Dispose();
         }
 
+#if NETFRAMEWORK
+        /// <summary>
+        /// This test can only fail when run on the .NET Framework in 64-bit release build using RyuJIT.
+        /// </summary>
+        [Test]
+        public void ThreadAbortExceptionExitsWorker()
+        {
+            var domain = AppDomain.CreateDomain("ThreadAbortExceptionExitsWorkerTest");
+
+            var domainDelegate = (AppDomainDelegate)domain.CreateInstanceFromAndUnwrap(
+                typeof(AppDomainDelegate).Assembly.Location,
+                typeof(AppDomainDelegate).FullName);
+
+            domainDelegate.Execute();
+
+            Assert.DoesNotThrow(() => AppDomain.Unload(domain));
+        }
+
+        private class AppDomainDelegate : MarshalByRefObject
+        {
+            public void Execute()
+            {
+                // This intentionally avoids referencing AsynchronousWorkerTests types
+                // because the assembly would fail to load
+                _ = new AsynchronousWorker<int>(
+                    new Mock<IAsynchronousWorkerHandler<int>>().Object,
+                    new Mock<IWaiter>().Object,
+                    1,
+                    10,
+                    null);
+            }
+        }
+#endif
+
         private AsynchronousWorker<int> CreateWorker(int workerThreadCount = 2)
         {
             var worker = new AsynchronousWorker<int>(

--- a/tests/StatsdClient.Tests/utils/AbstractServer.cs
+++ b/tests/StatsdClient.Tests/utils/AbstractServer.cs
@@ -7,6 +7,8 @@ namespace Tests.Utils
 {
     internal abstract class AbstractServer : IDisposable
     {
+        private static readonly char[] MessageSplitChars = new[] { '\n' };
+
         private readonly ManualResetEventSlim _serverStop = new ManualResetEventSlim(false);
         private readonly List<string> _messagesReceived = new List<string>();
         private Task _receiver;
@@ -52,7 +54,7 @@ namespace Tests.Utils
                 if (count.HasValue && count.Value > 0)
                 {
                     var message = System.Text.Encoding.UTF8.GetString(buffer, 0, count.Value);
-                    _messagesReceived.AddRange(message.Split("\n", StringSplitOptions.RemoveEmptyEntries));
+                    _messagesReceived.AddRange(message.Split(MessageSplitChars, StringSplitOptions.RemoveEmptyEntries));
                 }
                 else
                 {


### PR DESCRIPTION
This fixes #136 

I had to add `net461` as a target framework to the tests to be able to get a failing test.  A few additional minor changes to the test code were needed to make it compile.

The new test only has the potential to fail in 64-bit release mode using RyuJIT.  With ReleaseMode selected Resharper uses 64-bit by default, but for Visual Studio you can select 64-bit in the `Process Architecture for AnyCPU projects` menu option.

ThreadAbortException exists but is not used in .NET Core so this change will have no impact.

If you comment out the fix and since it's release mode add a Console.WriteLine [here](https://github.com/jdasilva-olo/dogstatsd-csharp-client/blob/jdasilva-olo/thread-abort-workaround/src/StatsdClient/Worker/AsynchronousWorker.cs#L118), you should be able to see the constant output of repeating ThreadAbortExceptions.