### PR TITLE
Use dedicated threads for background workers

### DIFF
--- a/src/StatsdClient/Worker/AsynchronousWorker.cs
+++ b/src/StatsdClient/Worker/AsynchronousWorker.cs
@@ -45,7 +45,7 @@ namespace StatsdClient.Worker
             _waiter = waiter;
             for (int i = 0; i < workerThreadCount; ++i)
             {
-                _workers.Add(Task.Run(() => Dequeue()));
+                _workers.Add(Task.Factory.StartNew(() => Dequeue(), TaskCreationOptions.LongRunning));
             }
         }
 


### PR DESCRIPTION
Long-running operations (> 500 ms) should always go to a dedicated thread. 

I used to think it didn't matter much, but I just ran into a situation where the threadpool wasn't scaling properly, and keeping this threadpool worker just to wait on a queue was causing a significant drop in a throughput.