### PR TITLE
Remove System.Net.NameResolution for netstandard2.0

### DIFF
--- a/src/StatsdClient/StatsdClient.csproj
+++ b/src/StatsdClient/StatsdClient.csproj
@@ -19,7 +19,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard1.3' ">
     <DefineConstants>NAMED_PIPE_AVAILABLE</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net45' AND '$(TargetFramework)' != 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Net.NameResolution">
       <Version>4.3.0</Version>
     </PackageReference>


### PR DESCRIPTION
The types available in System.Net.NameResolution seem to be built in as of `netstandard2.0`, so I switched the dependency to be only for `netstandard1.3`.

https://www.nuget.org/packages/System.Net.NameResolution
https://docs.microsoft.com/en-us/dotnet/api/system.net.dns