### PR TITLE
Use Thread.Sleep instead of Task.Delay when possible

### DIFF
--- a/src/StatsdClient/Worker/Waiter.cs
+++ b/src/StatsdClient/Worker/Waiter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 
 namespace StatsdClient.Worker
 {
@@ -7,7 +6,11 @@ namespace StatsdClient.Worker
     {
         public void Wait(TimeSpan duration)
         {
-            Task.Delay(duration).Wait();
+#if NETSTANDARD1_3
+            System.Threading.Tasks.Task.Delay(duration).Wait();
+#else
+            System.Threading.Thread.Sleep(duration);
+#endif
         }
     }
 }


### PR DESCRIPTION
`Thread.Sleep` is not available in netstandard 1.3, but no need to pay the overhead on the other platforms.