### PR TITLE
Improve performance

### DIFF
--- a/src/StatsdClient/Aggregator/CountAggregator.cs
+++ b/src/StatsdClient/Aggregator/CountAggregator.cs
@@ -12,7 +12,10 @@ namespace StatsdClient.Aggregator
 
         public CountAggregator(MetricAggregatorParameters parameters)
         {
-            _aggregator = new AggregatorFlusher<StatsMetric>(parameters, MetricType.Count);
+            _aggregator = new AggregatorFlusher<StatsMetric>(
+                parameters,
+                MetricType.Count,
+                (a, v) => a.FlushStatsMetric(v));
         }
 
         public void OnNewValue(ref StatsMetric metric)
@@ -42,15 +45,7 @@ namespace StatsdClient.Aggregator
 
         public void TryFlush(bool force = false)
         {
-            _aggregator.TryFlush(
-                values =>
-                {
-                    foreach (var keyValue in values)
-                    {
-                        _aggregator.FlushStatsMetric(keyValue.Value);
-                    }
-                },
-                force);
+            _aggregator.TryFlush(force);
         }
     }
 }

--- a/src/StatsdClient/Aggregator/GaugeAggregator.cs
+++ b/src/StatsdClient/Aggregator/GaugeAggregator.cs
@@ -11,7 +11,10 @@ namespace StatsdClient.Aggregator
 
         public GaugeAggregator(MetricAggregatorParameters parameters)
         {
-            _aggregator = new AggregatorFlusher<StatsMetric>(parameters, MetricType.Gauge);
+            _aggregator = new AggregatorFlusher<StatsMetric>(
+                parameters,
+                MetricType.Gauge,
+                (a, v) => a.FlushStatsMetric(v));
         }
 
         public void OnNewValue(ref StatsMetric metric)
@@ -31,15 +34,7 @@ namespace StatsdClient.Aggregator
 
         public void TryFlush(bool force = false)
         {
-            _aggregator.TryFlush(
-                values =>
-                {
-                    foreach (var keyValue in values)
-                    {
-                        _aggregator.FlushStatsMetric(keyValue.Value);
-                    }
-                },
-                force);
+            _aggregator.TryFlush(force);
         }
     }
 }

--- a/src/StatsdClient/RandomGenerator.cs
+++ b/src/StatsdClient/RandomGenerator.cs
@@ -11,7 +11,7 @@ namespace StatsdClient
 
         public bool ShouldSend(double sampleRate)
         {
-            return _random.NextDouble() < sampleRate;
+            return sampleRate >= 1 || _random.NextDouble() < sampleRate;
         }
     }
 }

--- a/tests/StatsdClient.Tests/Aggregator/AggregatorFlusherTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/AggregatorFlusherTests.cs
@@ -20,7 +20,7 @@ namespace StatsdClient.Tests.Aggregator
                 TimeSpan.FromMinutes(1),
                 maxUniqueStatsBeforeFlush: 3);
 
-            var aggregator = new AggregatorFlusher<StatsMetric>(parameters, MetricType.Count);
+            var aggregator = new AggregatorFlusher<StatsMetric>(parameters, MetricType.Count, (a, v) => a.FlushStatsMetric(v));
             Add(aggregator, "key1", new StatsMetric { });
             Add(aggregator, "key2", new StatsMetric { });
             Flush(aggregator);
@@ -48,7 +48,7 @@ namespace StatsdClient.Tests.Aggregator
                 TimeSpan.FromMilliseconds(500),
                 maxUniqueStatsBeforeFlush: 100);
 
-            var aggregator = new AggregatorFlusher<StatsMetric>(parameters, MetricType.Count);
+            var aggregator = new AggregatorFlusher<StatsMetric>(parameters, MetricType.Count, (a, v) => a.FlushStatsMetric(v));
             Add(aggregator, "key", new StatsMetric { });
             Flush(aggregator);
             handler.Verify(h => h.Handle(It.IsAny<byte[]>(), It.IsAny<int>()), Times.Never());
@@ -66,14 +66,7 @@ namespace StatsdClient.Tests.Aggregator
 
         private static void Flush(AggregatorFlusher<StatsMetric> aggregator, bool force = false)
         {
-            aggregator.TryFlush(
-                values =>
-            {
-                foreach (var keyValue in values)
-                {
-                    aggregator.FlushStatsMetric(keyValue.Value);
-                }
-            }, force);
+            aggregator.TryFlush(force);
         }
     }
 }


### PR DESCRIPTION
Improve the performance for `RandomGenerator`.
Remove some allocations in `CountAggregator`, `GaugeAggregator` and `CountAggregator`.