### PR TITLE
For event, use the size of the title and the text in UTF8.

### DIFF
--- a/src/StatsdClient/Serializer/EventSerializer.cs
+++ b/src/StatsdClient/Serializer/EventSerializer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Text;
 using StatsdClient.Statistic;
 
 namespace StatsdClient
@@ -22,9 +23,9 @@ namespace StatsdClient
             var builder = serializedMetric.Builder;
 
             builder.Append("_e{");
-            builder.AppendFormat(CultureInfo.InvariantCulture, "{0}", processedTitle.Length);
+            builder.AppendFormat(CultureInfo.InvariantCulture, "{0}", Encoding.UTF8.GetByteCount(processedTitle));
             builder.Append(',');
-            builder.AppendFormat(CultureInfo.InvariantCulture, "{0}", processedText.Length);
+            builder.AppendFormat(CultureInfo.InvariantCulture, "{0}", Encoding.UTF8.GetByteCount(processedText));
             builder.Append("}:");
             builder.Append(processedTitle);
             builder.Append('|');

--- a/tests/StatsdClient.Tests/CommandIntegrationTests.cs
+++ b/tests/StatsdClient.Tests/CommandIntegrationTests.cs
@@ -581,8 +581,8 @@ namespace Tests
         [Test]
         public void Events_aggregation_key_and_tags()
         {
-            _dogStatsdService.Event("Title", "♬ †øU †øU ¥ºu T0µ ♪", aggregationKey: "key", tags: new[] { "t1", "t2:v2" });
-            AssertWasReceived("_e{5,19}:Title|♬ †øU †øU ¥ºu T0µ ♪|k:key|#t1,t2:v2");
+            _dogStatsdService.Event("Title♬", "♬ †øU †øU ¥ºu T0µ ♪", aggregationKey: "key", tags: new[] { "t1", "t2:v2" });
+            AssertWasReceived("_e{8,32}:Title♬|♬ †øU †øU ¥ºu T0µ ♪|k:key|#t1,t2:v2");
         }
 
         [Test]


### PR DESCRIPTION
When a DogStatsD client sends an event, the message looks like 
`"_e{5,4}:title|text|p:low"`.
` _e{5,4}` is the header of the event.

`5` is the size of the title (`title` in this example) and `4` is the size of the text (`text` in this example).

DogStatsD clients must send the size in bytes for the text and for the title and not the size in char. It is an issue when the text or the title contains non ASCII chars.