### PR TITLE
Update client side flush interval from 3s to 2s.

### DIFF
--- a/src/StatsdClient/ClientSideAggregationConfig.cs
+++ b/src/StatsdClient/ClientSideAggregationConfig.cs
@@ -15,6 +15,6 @@ namespace StatsdClient
         /// <summary>
         /// Gets or sets the maximum interval duration between two flushes.
         /// </summary>
-        public TimeSpan FlushInterval { get; set; } = TimeSpan.FromSeconds(3);
+        public TimeSpan FlushInterval { get; set; } = TimeSpan.FromSeconds(2);
     }
 }


### PR DESCRIPTION
Update client side flush interval from 3s to 2s.

Motivation: see https://github.com/DataDog/datadog-go/pull/199.