### PR TITLE
Fix the implementation of MetricStatsKey.GetHashCode()

### DIFF
--- a/src/StatsdClient/Aggregator/MetricStatsKey.cs
+++ b/src/StatsdClient/Aggregator/MetricStatsKey.cs
@@ -17,21 +17,49 @@ namespace StatsdClient.Aggregator
             _tags = tags;
         }
 
-        // This code was auto generated
         public override bool Equals(object obj)
         {
-            return obj is MetricStatsKey key &&
-                   _metricName == key._metricName &&
-                   EqualityComparer<string[]>.Default.Equals(_tags, key._tags);
+            return obj is MetricStatsKey key
+                && _metricName == key._metricName
+                && AreEquals(_tags, key._tags);
         }
 
-        // This code was auto generated
         public override int GetHashCode()
         {
             int hashCode = -335110880;
-            hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(_metricName);
-            hashCode = (hashCode * -1521134295) + EqualityComparer<string[]>.Default.GetHashCode(_tags);
+            hashCode = (hashCode * -1521134295) + _metricName.GetHashCode();
+            if (_tags != null)
+            {
+                foreach (var tag in _tags)
+                {
+                    hashCode = (hashCode * -1521134295) + tag.GetHashCode();
+                }
+            }
+
             return hashCode;
+        }
+
+        private static bool AreEquals(string[] arr1, string[] arr2)
+        {
+            if (arr1 == null && arr2 == null)
+            {
+                return true;
+            }
+
+            if (arr1 == null || arr2 == null || arr1.Length != arr2.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < arr1.Length; i++)
+            {
+                if (arr1[i] != arr2[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/tests/StatsdClient.Tests/Aggregator/MetricStatsKeyTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/MetricStatsKeyTests.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+using StatsdClient.Aggregator;
+
+namespace StatsdClient.Tests.Aggregator
+{
+    [TestFixture]
+    public class MetricStatsKeyTests
+    {
+        [Test]
+        public void Equals()
+        {
+            Assert.AreEqual(
+                new MetricStatsKey("m1", new[] { "tag" }),
+                new MetricStatsKey("m1", new[] { "tag" }));
+            Assert.AreNotEqual(
+                new MetricStatsKey("m1", new[] { "tag" }),
+                new MetricStatsKey("m2", new[] { "tag" }));
+            Assert.AreNotEqual(
+                new MetricStatsKey("m1", new[] { "tag" }),
+                new MetricStatsKey("m1", new[] { "tag2" }));
+        }
+
+        [Test]
+        public void HashCode()
+        {
+            Assert.AreEqual(
+                new MetricStatsKey("m1", new[] { "tag" }).GetHashCode(),
+                new MetricStatsKey("m1", new[] { "tag" }).GetHashCode());
+        }
+    }
+}


### PR DESCRIPTION
Fix the implementation of `MetricStatsKey.GetHashCode` and `MetricStatsKey.Equals`.
`EqualityComparer<string[]>.Default.GetHashCode()` returns the HashCode of the address of the array.