### PR TITLE
Add end of line separator after each message.

### DIFF
--- a/src/StatsdClient/Bufferize/BufferBuilder.cs
+++ b/src/StatsdClient/Bufferize/BufferBuilder.cs
@@ -62,10 +62,8 @@ namespace StatsdClient.Bufferize
                     throw new InvalidOperationException($"The metric size exceeds the buffer capacity {Capacity}: {serializedMetric.ToString()}");
                 }
 
-                if (Length != 0)
-                {
-                    byteCount++;
-                }
+                // For separator
+                byteCount++;
 
                 if (Length + byteCount > Capacity)
                 {
@@ -73,14 +71,11 @@ namespace StatsdClient.Bufferize
                 }
             }
 
-            if (Length != 0)
-            {
-                _buffer[Length] = _separator;
-                Length++;
-            }
-
             // GetBytes requires the buffer to be big enough otherwise it throws.
             Length += _encoding.GetBytes(_charsBuffers, 0, length, _buffer, Length);
+
+            _buffer[Length] = _separator;
+            Length++;
         }
 
         public void HandleBufferAndReset()

--- a/tests/StatsdClient.Tests/Aggregator/CountAggregatorTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/CountAggregatorTests.cs
@@ -20,11 +20,11 @@ namespace StatsdClient.Tests.Aggregator
             AddStatsMetric(aggregator, "s1", 2);
             AddStatsMetric(aggregator, "s2", 2);
             aggregator.TryFlush(force: true);
-            Assert.AreEqual("s1:3|c,s2:2|c", handler.Value);
+            Assert.AreEqual("s1:3|c\ns2:2|c\n", handler.Value);
 
             AddStatsMetric(aggregator, "s3", 1);
             aggregator.TryFlush(force: true);
-            Assert.AreEqual("s3:1|c", handler.Value);
+            Assert.AreEqual("s3:1|c\n", handler.Value);
         }
 
         [Test]

--- a/tests/StatsdClient.Tests/Aggregator/GaugeAggregatorTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/GaugeAggregatorTests.cs
@@ -17,7 +17,7 @@ namespace StatsdClient.Tests.Aggregator
             AddStatsMetric(aggregator, "s2", 3);
             aggregator.TryFlush(force: true);
 
-            Assert.AreEqual("s1:2|g|@0,s2:3|g|@0", handler.Value);
+            Assert.AreEqual("s1:2|g|@0\ns2:3|g|@0\n", handler.Value);
         }
 
         private static void AddStatsMetric(GaugeAggregator aggregator, string statName, double value)

--- a/tests/StatsdClient.Tests/Aggregator/MetricAggregatorParametersFactory.cs
+++ b/tests/StatsdClient.Tests/Aggregator/MetricAggregatorParametersFactory.cs
@@ -20,7 +20,7 @@ namespace StatsdClient.Tests.Aggregator
             int maxUniqueStatsBeforeFlush)
         {
             var serializer = new MetricSerializer(new SerializerHelper(null), string.Empty);
-            var bufferBuilder = new BufferBuilder(handler, bufferCapacity: 1000, ",");
+            var bufferBuilder = new BufferBuilder(handler, bufferCapacity: 1000, "\n");
 
             return new MetricAggregatorParameters(
                 serializer,

--- a/tests/StatsdClient.Tests/Aggregator/SetAggregatorTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/SetAggregatorTests.cs
@@ -19,11 +19,11 @@ namespace StatsdClient.Tests.Aggregator
             AddStatsMetric(aggregator, "s1", "2");
             AddStatsMetric(aggregator, "s2", "3");
             aggregator.TryFlush(force: true);
-            Assert.AreEqual("s1:1|s|@0,s1:2|s|@0,s2:3|s|@0", handler.Value);
+            Assert.AreEqual("s1:1|s|@0\ns1:2|s|@0\ns2:3|s|@0\n", handler.Value);
 
             AddStatsMetric(aggregator, "s1", "4");
             aggregator.TryFlush(force: true);
-            Assert.AreEqual("s1:4|s|@0", handler.Value);
+            Assert.AreEqual("s1:4|s|@0\n", handler.Value);
         }
 
         [Test]
@@ -37,7 +37,7 @@ namespace StatsdClient.Tests.Aggregator
             for (int i = 0; i < 10; ++i)
             {
                 AddStatsMetric(aggregator, "s1", i.ToString());
-                Assert.AreEqual($"s1:{i}|s|@0", handler.Value);
+                Assert.AreEqual($"s1:{i}|s|@0\n", handler.Value);
             }
         }
 

--- a/tests/StatsdClient.Tests/Bufferize/BufferBuilderTests.cs
+++ b/tests/StatsdClient.Tests/Bufferize/BufferBuilderTests.cs
@@ -3,7 +3,6 @@ using System.Text;
 using NUnit.Framework;
 using StatsdClient;
 using StatsdClient.Bufferize;
-using StatsdClient.Utils;
 
 namespace Tests
 {
@@ -30,8 +29,8 @@ namespace Tests
             _bufferBuilder.Add(CreateSerializedMetric('3', 3));
             Assert.Null(_handler.Buffer);
             _bufferBuilder.Add(CreateSerializedMetric('4', 3));
-            Assert.AreEqual(3, _bufferBuilder.Length);
-            Assert.AreEqual(_handler.Buffer, Encoding.UTF8.GetBytes("111\n222\n333"));
+            Assert.AreEqual(4, _bufferBuilder.Length);
+            Assert.AreEqual("111\n222\n333\n", Encoding.UTF8.GetString(_handler.Buffer));
         }
 
         [Test]
@@ -40,11 +39,11 @@ namespace Tests
             Assert.Less(4, _bufferBuilder.Capacity);
             _bufferBuilder.Add(CreateSerializedMetric('1', 2));
             _bufferBuilder.HandleBufferAndReset();
-            Assert.AreEqual(_handler.Buffer, Encoding.UTF8.GetBytes("11"));
+            Assert.AreEqual("11\n", Encoding.UTF8.GetString(_handler.Buffer));
 
             _bufferBuilder.Add(CreateSerializedMetric('3', 4));
             _bufferBuilder.HandleBufferAndReset();
-            Assert.AreEqual(_handler.Buffer, Encoding.UTF8.GetBytes("3333"));
+            Assert.AreEqual("3333\n", Encoding.UTF8.GetString(_handler.Buffer));
         }
 
         [Test]
@@ -53,7 +52,7 @@ namespace Tests
             Assert.Throws<InvalidOperationException>(() => _bufferBuilder.Add(CreateSerializedMetric('1', _bufferBuilder.Capacity + 1)));
             Assert.AreEqual(0, _bufferBuilder.Length);
 
-            _bufferBuilder.Add(CreateSerializedMetric('1', _bufferBuilder.Capacity));
+            _bufferBuilder.Add(CreateSerializedMetric('1', _bufferBuilder.Capacity - 1)); // -1 for separator
             Assert.AreEqual(_bufferBuilder.Capacity, _bufferBuilder.Length);
         }
 

--- a/tests/StatsdClient.Tests/Bufferize/StatsBufferizeTests.cs
+++ b/tests/StatsdClient.Tests/Bufferize/StatsBufferizeTests.cs
@@ -37,7 +37,7 @@ namespace Tests
                 }
 
                 // Sent because buffer is full.
-                Assert.AreEqual("_e{5,4}:title|test", Encoding.UTF8.GetString(handler.Buffer));
+                Assert.AreEqual("_e{5,4}:title|test\n", Encoding.UTF8.GetString(handler.Buffer));
             }
         }
     }

--- a/tests/StatsdClient.Tests/CommandIntegrationTests.cs
+++ b/tests/StatsdClient.Tests/CommandIntegrationTests.cs
@@ -670,7 +670,7 @@ namespace Tests
             {
             }
 
-            Assert.AreEqual(shouldBe, _udpListener.GetAndClearLastMessages()[index]);
+            Assert.AreEqual(shouldBe + "\n", _udpListener.GetAndClearLastMessages()[index]);
         }
 
         // Test helper. Waits until the listener is done receiving a message,

--- a/tests/StatsdClient.Tests/DogStatsdServiceConfigurationTest.cs
+++ b/tests/StatsdClient.Tests/DogStatsdServiceConfigurationTest.cs
@@ -27,7 +27,7 @@ namespace Tests
                     8125,
                     () => { nonStaticServiceInstance.Increment("test"); });
 
-                Assert.AreEqual(new List<string> { "test:1|c" }, receivedData);
+                Assert.AreEqual(new List<string> { "test:1|c\n" }, receivedData);
             }
         }
 
@@ -49,7 +49,7 @@ namespace Tests
                     8126,
                     () => { nonStaticServiceInstance.Increment("test"); });
 
-                Assert.AreEqual(new List<string> { "test:1|c" }, receivedData);
+                Assert.AreEqual(new List<string> { "test:1|c\n" }, receivedData);
             }
         }
 
@@ -92,7 +92,7 @@ namespace Tests
                     8129,
                     () => { nonStaticServiceInstance.Increment("test"); });
 
-                Assert.AreEqual(new List<string> { "prefix.test:1|c" }, receivedData);
+                Assert.AreEqual(new List<string> { "prefix.test:1|c\n" }, receivedData);
             }
         }
 
@@ -156,7 +156,7 @@ namespace Tests
                     8131,
                     () => { nonStaticServiceInstance.Increment("test"); });
 
-                Assert.AreEqual(new List<string> { "test:1|c" }, receivedData);
+                Assert.AreEqual(new List<string> { "test:1|c\n" }, receivedData);
             }
 
             Environment.SetEnvironmentVariable("DD_DOGSTATSD_PORT", null);
@@ -188,7 +188,7 @@ namespace Tests
                         8132,
                         () => { nonStaticServiceInstance.Increment("test"); });
 
-                    Assert.AreEqual(new List<string> { $"test:1|c|#{tag}:foobar" }, receivedData);
+                    Assert.AreEqual(new List<string> { $"test:1|c|#{tag}:foobar\n" }, receivedData);
                 }
             }
             finally

--- a/tests/StatsdClient.Tests/DogStatsdServiceTelemetryTests.cs
+++ b/tests/StatsdClient.Tests/DogStatsdServiceTelemetryTests.cs
@@ -72,7 +72,7 @@ namespace Tests
             await Task.Delay(TimeSpan.FromMilliseconds(500));
 
             Assert.AreEqual(1, _service.TelemetryCounters.PacketsSent);
-            Assert.AreEqual(8, _service.TelemetryCounters.BytesSent);
+            Assert.AreEqual(9, _service.TelemetryCounters.BytesSent);
         }
 
 #if !OS_WINDOWS

--- a/tests/StatsdClient.Tests/DogstatsdStaticApiTests.cs
+++ b/tests/StatsdClient.Tests/DogstatsdStaticApiTests.cs
@@ -55,7 +55,7 @@ namespace Tests
         public void Distribution_should_be_received()
         {
             DogStatsd.Distribution("distribution", 42);
-            AssertWasReceived("distribution:42|d");
+            AssertWasReceived("distribution:42|d\n");
         }
 
         // Test helper. Waits until the listener is done receiving a message,

--- a/tests/StatsdClient.Tests/StatsdConfigurationTests.cs
+++ b/tests/StatsdClient.Tests/StatsdConfigurationTests.cs
@@ -36,7 +36,7 @@ namespace Tests
                     StatsdServerName = "127.0.0.1",
                 };
                 sut.Configure(metricsConfig);
-                TestReceive("127.0.0.1", 8125, "test", "test:1|c", sut);
+                TestReceive("127.0.0.1", 8125, "test", "test:1|c\n", sut);
             }
         }
 
@@ -51,7 +51,7 @@ namespace Tests
                     StatsdPort = 8126,
                 };
                 sut.Configure(metricsConfig);
-                TestReceive("127.0.0.1", 8126, "test", "test:1|c", sut);
+                TestReceive("127.0.0.1", 8126, "test", "test:1|c\n", sut);
             }
         }
 
@@ -67,7 +67,7 @@ namespace Tests
                     Prefix = "prefix",
                 };
                 sut.Configure(metricsConfig);
-                TestReceive("127.0.0.1", 8129, "test", "prefix.test:1|c", sut);
+                TestReceive("127.0.0.1", 8129, "test", "prefix.test:1|c\n", sut);
             }
         }
 

--- a/tests/StatsdClient.Tests/StatsdUnixDomainSocketTests.cs
+++ b/tests/StatsdClient.Tests/StatsdUnixDomainSocketTests.cs
@@ -43,7 +43,7 @@ namespace Tests
                     var metric = "gas_tank.level";
                     var value = 0.75;
                     service.Gauge(metric, value);
-                    Assert.AreEqual($"{metric}:{value}|g", ReadFromServer(socket));
+                    Assert.AreEqual($"{metric}:{value}|g\n", ReadFromServer(socket));
                 }
             }
         }


### PR DESCRIPTION
Add end of line separator after each message.
For example, instead of sending `test:1|c` sends, `test:1|c\n`.