### PR TITLE
Don't throw an exception when the metric is too long

### DIFF
--- a/src/StatsdClient/Bufferize/BufferBuilder.cs
+++ b/src/StatsdClient/Bufferize/BufferBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Text;
 
 namespace StatsdClient.Bufferize
@@ -47,7 +48,8 @@ namespace StatsdClient.Bufferize
 
             if (length < 0)
             {
-                throw new InvalidOperationException($"The metric size exceeds the internal buffer capacity {_charsBuffers.Length}: {serializedMetric.ToString()}");
+                Debug.WriteLine($"The metric size exceeds the internal buffer capacity {_charsBuffers.Length}: {serializedMetric.ToString()}");
+                return;
             }
 
             // Heuristic to know if there is enough space without calling `GetByteCount`.
@@ -59,7 +61,8 @@ namespace StatsdClient.Bufferize
 
                 if (byteCount > Capacity)
                 {
-                    throw new InvalidOperationException($"The metric size exceeds the buffer capacity {Capacity}: {serializedMetric.ToString()}");
+                    Debug.WriteLine($"The metric size exceeds the buffer capacity {Capacity}: {serializedMetric.ToString()}");
+                    return;
                 }
 
                 // For separator

--- a/tests/StatsdClient.Tests/Bufferize/BufferBuilderTests.cs
+++ b/tests/StatsdClient.Tests/Bufferize/BufferBuilderTests.cs
@@ -49,9 +49,6 @@ namespace Tests
         [Test]
         public void AddReturnedValue()
         {
-            Assert.Throws<InvalidOperationException>(() => _bufferBuilder.Add(CreateSerializedMetric('1', _bufferBuilder.Capacity + 1)));
-            Assert.AreEqual(0, _bufferBuilder.Length);
-
             _bufferBuilder.Add(CreateSerializedMetric('1', _bufferBuilder.Capacity - 1)); // -1 for separator
             Assert.AreEqual(_bufferBuilder.Capacity, _bufferBuilder.Length);
         }


### PR DESCRIPTION
Don't throw an exception when the size of the metric exceeds the internal buffer capacity.

This PR should solves https://github.com/DataDog/dogstatsd-csharp-client/issues/176. 

