### PR TITLE
[CODEOWNERS] Specify `@DataDog/agent-metrics-logs` as owners of this repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,8 @@
 # Rules are matched bottom-to-top, so one team can own subdirectories
 # and another the rest of the directory.
 
+# Global repo owner
+*                     @DataDog/agent-metrics-logs
 
 # Documentation
 *.md                  @DataDog/baklava


### PR DESCRIPTION
Old codeowners was missing a global owner so this change lists
that explicitly.