### PR TITLE
Add an exception handler.

### DIFF
--- a/benchmarks/StatsdClient.Benchmarks/BufferBuilderBenchmark.cs
+++ b/benchmarks/StatsdClient.Benchmarks/BufferBuilderBenchmark.cs
@@ -16,7 +16,7 @@ namespace StatsdClient.Benchmarks
         {
             _serializedMetric = new SerializedMetric();
             _serializedMetric.Builder.Append(new String('A', 128));
-            _bufferBuilder = new BufferBuilder(new EmptyHandler(), 8096, "\n");
+            _bufferBuilder = new BufferBuilder(new EmptyHandler(), 8096, "\n", null);
         }
         class EmptyHandler : IBufferBuilderHandler
         {

--- a/src/StatsdClient/Aggregator/SetAggregator.cs
+++ b/src/StatsdClient/Aggregator/SetAggregator.cs
@@ -14,7 +14,7 @@ namespace StatsdClient.Aggregator
         private readonly Pool<StatsMetricSet> _pool;
         private readonly Telemetry _optionalTelemetry;
 
-        public SetAggregator(MetricAggregatorParameters parameters, Telemetry optionalTelemetry)
+        public SetAggregator(MetricAggregatorParameters parameters, Telemetry optionalTelemetry, Action<Exception> optionalExceptionHandler)
         {
             Action<AggregatorFlusher<StatsMetricSet>, StatsMetricSet> flushMetric = (agg, statsMetric) =>
             {
@@ -29,7 +29,7 @@ namespace StatsdClient.Aggregator
                 }
             };
             _aggregator = new AggregatorFlusher<StatsMetricSet>(parameters, MetricType.Set, flushMetric);
-            _pool = new Pool<StatsMetricSet>(pool => new StatsMetricSet(pool), 2 * parameters.MaxUniqueStatsBeforeFlush);
+            _pool = new Pool<StatsMetricSet>(pool => new StatsMetricSet(pool, optionalExceptionHandler), 2 * parameters.MaxUniqueStatsBeforeFlush);
             _optionalTelemetry = optionalTelemetry;
         }
 
@@ -66,8 +66,8 @@ namespace StatsdClient.Aggregator
 
         private class StatsMetricSet : AbstractPoolObject
         {
-            public StatsMetricSet(IPool pool)
-            : base(pool)
+            public StatsMetricSet(IPool pool, Action<Exception> optionalExceptionHandler)
+            : base(pool, optionalExceptionHandler)
             {
             }
 

--- a/src/StatsdClient/Bufferize/IStatsBufferizeFactory.cs
+++ b/src/StatsdClient/Bufferize/IStatsBufferizeFactory.cs
@@ -16,7 +16,8 @@ namespace StatsdClient.Bufferize
           StatsRouter statsRouter,
           int workerMaxItemCount,
           TimeSpan? blockingQueueTimeout,
-          TimeSpan maxIdleWaitBeforeSending);
+          TimeSpan maxIdleWaitBeforeSending,
+          Action<Exception> optionalExceptionHandler);
 
         StatsRouter CreateStatsRouter(
             Serializers serializers,
@@ -36,6 +37,7 @@ namespace StatsdClient.Bufferize
             string assemblyVersion,
             TimeSpan flushInterval,
             ITransport transport,
-            string[] globalTags);
+            string[] globalTags,
+            Action<Exception> optionalExceptionHandler);
     }
 }

--- a/src/StatsdClient/Bufferize/StatsBufferize.cs
+++ b/src/StatsdClient/Bufferize/StatsBufferize.cs
@@ -15,7 +15,8 @@ namespace StatsdClient.Bufferize
             StatsRouter statsRouter,
             int workerMaxItemCount,
             TimeSpan? blockingQueueTimeout,
-            TimeSpan maxIdleWaitBeforeSending)
+            TimeSpan maxIdleWaitBeforeSending,
+            Action<Exception> optionalExceptionHandler)
         {
             var handler = new WorkerHandler(statsRouter, maxIdleWaitBeforeSending);
 
@@ -26,7 +27,8 @@ namespace StatsdClient.Bufferize
                 new Waiter(),
                 workerThreadCount: 1,
                 workerMaxItemCount,
-                blockingQueueTimeout);
+                blockingQueueTimeout,
+                optionalExceptionHandler);
         }
 
         public void Send(Stats serializedMetric) => this._worker.Enqueue(serializedMetric);

--- a/src/StatsdClient/Bufferize/StatsBufferizeFactory.cs
+++ b/src/StatsdClient/Bufferize/StatsBufferizeFactory.cs
@@ -12,13 +12,15 @@ namespace StatsdClient.Bufferize
             StatsRouter statsRouter,
             int workerMaxItemCount,
             TimeSpan? blockingQueueTimeout,
-            TimeSpan maxIdleWaitBeforeSending)
+            TimeSpan maxIdleWaitBeforeSending,
+            Action<Exception> optionalExceptionHandler)
         {
             return new StatsBufferize(
                 statsRouter,
                 workerMaxItemCount,
                 blockingQueueTimeout,
-                maxIdleWaitBeforeSending);
+                maxIdleWaitBeforeSending,
+                optionalExceptionHandler);
         }
 
         public StatsRouter CreateStatsRouter(
@@ -41,9 +43,15 @@ namespace StatsdClient.Bufferize
             return new UnixDomainSocketTransport(endPoint, udsBufferFullBlockDuration);
         }
 
-        public Telemetry CreateTelemetry(MetricSerializer metricSerializer, string assemblyVersion, TimeSpan flushInterval, ITransport transport, string[] globalTags)
+        public Telemetry CreateTelemetry(
+            MetricSerializer metricSerializer,
+            string assemblyVersion,
+            TimeSpan flushInterval,
+            ITransport transport,
+            string[] globalTags,
+            Action<Exception> optionalExceptionHandler)
         {
-            return new Telemetry(metricSerializer, assemblyVersion, flushInterval, transport, globalTags);
+            return new Telemetry(metricSerializer, assemblyVersion, flushInterval, transport, globalTags, optionalExceptionHandler);
         }
 
         public ITransport CreateNamedPipeTransport(string pipeName)

--- a/src/StatsdClient/DogStatsdService.cs
+++ b/src/StatsdClient/DogStatsdService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Globalization;
 using StatsdClient.Bufferize;
 
@@ -32,6 +33,12 @@ namespace StatsdClient
         /// other methods in this class do nothing and an error is reported to <paramref name="optionalExceptionHandler"/>.</returns>
         public bool Configure(StatsdConfig config, Action<Exception> optionalExceptionHandler = null)
         {
+            var exceptionHandler = optionalExceptionHandler;
+            if (exceptionHandler == null)
+            {
+                exceptionHandler = e => Debug.WriteLine(e);
+            }
+
             try
             {
                 if (_statsdBuilder == null)
@@ -50,12 +57,12 @@ namespace StatsdClient
                 }
 
                 _config = config;
-                _statsdData = _statsdBuilder.BuildStatsData(config, optionalExceptionHandler);
+                _statsdData = _statsdBuilder.BuildStatsData(config, exceptionHandler);
                 _metricsSender = _statsdData.MetricsSender;
             }
             catch (Exception e)
             {
-                optionalExceptionHandler?.Invoke(e);
+                exceptionHandler.Invoke(e);
                 return false;
             }
 

--- a/src/StatsdClient/DogStatsdService.cs
+++ b/src/StatsdClient/DogStatsdService.cs
@@ -24,28 +24,42 @@ namespace StatsdClient
         /// <summary>
         /// Configures the instance.
         /// Must be called before any other methods.
+        /// Can be called once.
         /// </summary>
         /// <param name="config">The value of the config.</param>
-        public void Configure(StatsdConfig config)
+        /// <param name="optionalExceptionHandler">The handler called when an error occurs."</param>
+        /// <returns>Return true if the operation succeed, false otherwise. If this function fails,
+        /// other methods in this class do nothing and an error is reported to <paramref name="optionalExceptionHandler"/>.</returns>
+        public bool Configure(StatsdConfig config, Action<Exception> optionalExceptionHandler = null)
         {
-            if (_statsdBuilder == null)
+            try
             {
-                throw new ObjectDisposedException(nameof(DogStatsdService));
+                if (_statsdBuilder == null)
+                {
+                    throw new ObjectDisposedException(nameof(DogStatsdService));
+                }
+
+                if (config == null)
+                {
+                    throw new ArgumentNullException("config");
+                }
+
+                if (_config != null)
+                {
+                    throw new InvalidOperationException("Configuration for DogStatsdService already performed");
+                }
+
+                _config = config;
+                _statsdData = _statsdBuilder.BuildStatsData(config, optionalExceptionHandler);
+                _metricsSender = _statsdData.MetricsSender;
+            }
+            catch (Exception e)
+            {
+                optionalExceptionHandler?.Invoke(e);
+                return false;
             }
 
-            if (config == null)
-            {
-                throw new ArgumentNullException("config");
-            }
-
-            if (_config != null)
-            {
-                throw new InvalidOperationException("Configuration for DogStatsdService already performed");
-            }
-
-            _config = config;
-            _statsdData = _statsdBuilder.BuildStatsData(config);
-            _metricsSender = _statsdData.MetricsSender;
+            return true;
         }
 
         /// <summary>

--- a/src/StatsdClient/DogStatsdService.cs
+++ b/src/StatsdClient/DogStatsdService.cs
@@ -24,7 +24,7 @@ namespace StatsdClient
         /// <summary>
         /// Configures the instance.
         /// Must be called before any other methods.
-        /// Can be called once.
+        /// Can only be called once.
         /// </summary>
         /// <param name="config">The value of the config.</param>
         /// <param name="optionalExceptionHandler">The handler called when an error occurs."</param>

--- a/src/StatsdClient/IDogStatsd.cs
+++ b/src/StatsdClient/IDogStatsd.cs
@@ -16,9 +16,13 @@ namespace StatsdClient
         /// <summary>
         /// Configures the instance.
         /// Must be called before any other methods.
+        /// Can be called once.
         /// </summary>
         /// <param name="config">The value of the config.</param>
-        void Configure(StatsdConfig config);
+        /// <param name="optionalExceptionHandler">The handler called when an error occurs."</param>
+        /// <returns>Return true if the operation succeed, false otherwise. If this function fails,
+        /// other methods in this class do nothing and an error is reported to <paramref name="optionalExceptionHandler"/>.</returns>
+        bool Configure(StatsdConfig config, Action<Exception> optionalExceptionHandler = null);
 
         /// <summary>
         /// Adjusts the specified counter by a given delta.

--- a/src/StatsdClient/IDogStatsd.cs
+++ b/src/StatsdClient/IDogStatsd.cs
@@ -16,7 +16,7 @@ namespace StatsdClient
         /// <summary>
         /// Configures the instance.
         /// Must be called before any other methods.
-        /// Can be called once.
+        /// Can only be called once.
         /// </summary>
         /// <param name="config">The value of the config.</param>
         /// <param name="optionalExceptionHandler">The handler called when an error occurs."</param>

--- a/src/StatsdClient/Utils/AbstractPoolObject.cs
+++ b/src/StatsdClient/Utils/AbstractPoolObject.cs
@@ -1,16 +1,17 @@
 using System;
-using System.Diagnostics;
 
 namespace StatsdClient.Utils
 {
     internal abstract class AbstractPoolObject : IDisposable
     {
         private readonly IPool _pool;
+        private readonly Action<Exception> _optionalExceptionHandler;
         private bool _enqueue = false;
 
-        public AbstractPoolObject(IPool pool)
+        public AbstractPoolObject(IPool pool, Action<Exception> optionalExceptionHandler)
         {
             _pool = pool;
+            _optionalExceptionHandler = optionalExceptionHandler;
         }
 
         ~AbstractPoolObject()
@@ -21,7 +22,7 @@ namespace StatsdClient.Utils
             }
             catch (Exception e)
             {
-                Debug.WriteLine(e.Message);
+                _optionalExceptionHandler?.Invoke(e);
             }
         }
 

--- a/tests/StatsdClient.Tests/Aggregator/MetricAggregatorParametersFactory.cs
+++ b/tests/StatsdClient.Tests/Aggregator/MetricAggregatorParametersFactory.cs
@@ -20,7 +20,7 @@ namespace StatsdClient.Tests.Aggregator
             int maxUniqueStatsBeforeFlush)
         {
             var serializer = new MetricSerializer(new SerializerHelper(null), string.Empty);
-            var bufferBuilder = new BufferBuilder(handler, bufferCapacity: 1000, "\n");
+            var bufferBuilder = new BufferBuilder(handler, bufferCapacity: 1000, "\n", null);
 
             return new MetricAggregatorParameters(
                 serializer,

--- a/tests/StatsdClient.Tests/Aggregator/MetricAggregatorParametersFactory.cs
+++ b/tests/StatsdClient.Tests/Aggregator/MetricAggregatorParametersFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using StatsdClient.Aggregator;
 using StatsdClient.Bufferize;
+using Tests.Utils;
 
 namespace StatsdClient.Tests.Aggregator
 {
@@ -20,7 +21,7 @@ namespace StatsdClient.Tests.Aggregator
             int maxUniqueStatsBeforeFlush)
         {
             var serializer = new MetricSerializer(new SerializerHelper(null), string.Empty);
-            var bufferBuilder = new BufferBuilder(handler, bufferCapacity: 1000, "\n", null);
+            var bufferBuilder = new BufferBuilder(handler, bufferCapacity: 1000, "\n", Tools.ExceptionHandler);
 
             return new MetricAggregatorParameters(
                 serializer,

--- a/tests/StatsdClient.Tests/Aggregator/SetAggregatorTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/SetAggregatorTests.cs
@@ -12,7 +12,7 @@ namespace StatsdClient.Tests.Aggregator
         public void OnNewValue()
         {
             var handler = new BufferBuilderHandlerMock();
-            var aggregator = new SetAggregator(MetricAggregatorParametersFactory.Create(handler.Object), null);
+            var aggregator = new SetAggregator(MetricAggregatorParametersFactory.Create(handler.Object), null, null);
             AddStatsMetric(aggregator, "s1", "1");
             AddStatsMetric(aggregator, "s1", "2");
             AddStatsMetric(aggregator, "s1", "2");
@@ -31,7 +31,7 @@ namespace StatsdClient.Tests.Aggregator
         {
             var handler = new BufferBuilderHandlerMock();
             var parameters = MetricAggregatorParametersFactory.Create(handler.Object, TimeSpan.FromMinutes(1), 1);
-            var aggregator = new SetAggregator(parameters, null);
+            var aggregator = new SetAggregator(parameters, null, null);
 
             // Check StatsMetricSet instance go back to the pool
             for (int i = 0; i < 10; ++i)

--- a/tests/StatsdClient.Tests/Aggregator/SetAggregatorTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/SetAggregatorTests.cs
@@ -2,6 +2,7 @@ using System;
 using NUnit.Framework;
 using StatsdClient.Aggregator;
 using StatsdClient.Statistic;
+using Tests.Utils;
 
 namespace StatsdClient.Tests.Aggregator
 {
@@ -12,7 +13,7 @@ namespace StatsdClient.Tests.Aggregator
         public void OnNewValue()
         {
             var handler = new BufferBuilderHandlerMock();
-            var aggregator = new SetAggregator(MetricAggregatorParametersFactory.Create(handler.Object), null, null);
+            var aggregator = new SetAggregator(MetricAggregatorParametersFactory.Create(handler.Object), null, Tools.ExceptionHandler);
             AddStatsMetric(aggregator, "s1", "1");
             AddStatsMetric(aggregator, "s1", "2");
             AddStatsMetric(aggregator, "s1", "2");
@@ -31,7 +32,7 @@ namespace StatsdClient.Tests.Aggregator
         {
             var handler = new BufferBuilderHandlerMock();
             var parameters = MetricAggregatorParametersFactory.Create(handler.Object, TimeSpan.FromMinutes(1), 1);
-            var aggregator = new SetAggregator(parameters, null, null);
+            var aggregator = new SetAggregator(parameters, null, Tools.ExceptionHandler);
 
             // Check StatsMetricSet instance go back to the pool
             for (int i = 0; i < 10; ++i)

--- a/tests/StatsdClient.Tests/Bufferize/BufferBuilderTests.cs
+++ b/tests/StatsdClient.Tests/Bufferize/BufferBuilderTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using NUnit.Framework;
 using StatsdClient;
 using StatsdClient.Bufferize;
+using Tests.Utils;
 
 namespace Tests
 {
@@ -17,7 +18,7 @@ namespace Tests
         public void Init()
         {
             _handler = new BufferBuilderHandlerMock();
-            _bufferBuilder = new BufferBuilder(_handler, 12, "\n", null);
+            _bufferBuilder = new BufferBuilder(_handler, 12, "\n", Tools.ExceptionHandler);
         }
 
         [Test]

--- a/tests/StatsdClient.Tests/Bufferize/BufferBuilderTests.cs
+++ b/tests/StatsdClient.Tests/Bufferize/BufferBuilderTests.cs
@@ -17,7 +17,7 @@ namespace Tests
         public void Init()
         {
             _handler = new BufferBuilderHandlerMock();
-            _bufferBuilder = new BufferBuilder(_handler, 12, "\n");
+            _bufferBuilder = new BufferBuilder(_handler, 12, "\n", null);
         }
 
         [Test]

--- a/tests/StatsdClient.Tests/Bufferize/StatsBufferizeTests.cs
+++ b/tests/StatsdClient.Tests/Bufferize/StatsBufferizeTests.cs
@@ -18,13 +18,13 @@ namespace Tests
         public void StatsBufferize()
         {
             var handler = new BufferBuilderHandlerMock();
-            var bufferBuilder = new BufferBuilder(handler, 30, "\n");
+            var bufferBuilder = new BufferBuilder(handler, 30, "\n", null);
             var serializers = new Serializers
             {
                 EventSerializer = new EventSerializer(new SerializerHelper(null)),
             };
             var statsRouter = new StatsRouter(serializers, bufferBuilder, null);
-            using (var statsBufferize = new StatsBufferize(statsRouter, 10, null, TimeSpan.Zero))
+            using (var statsBufferize = new StatsBufferize(statsRouter, 10, null, TimeSpan.Zero, null))
             {
                 var stats = new Stats { Kind = StatsKind.Event };
                 stats.Event.Text = "test";

--- a/tests/StatsdClient.Tests/Bufferize/StatsBufferizeTests.cs
+++ b/tests/StatsdClient.Tests/Bufferize/StatsBufferizeTests.cs
@@ -7,6 +7,7 @@ using StatsdClient;
 using StatsdClient.Bufferize;
 using StatsdClient.Statistic;
 using StatsdClient.Utils;
+using Tests.Utils;
 
 namespace Tests
 {
@@ -18,13 +19,13 @@ namespace Tests
         public void StatsBufferize()
         {
             var handler = new BufferBuilderHandlerMock();
-            var bufferBuilder = new BufferBuilder(handler, 30, "\n", null);
+            var bufferBuilder = new BufferBuilder(handler, 30, "\n", Tools.ExceptionHandler);
             var serializers = new Serializers
             {
                 EventSerializer = new EventSerializer(new SerializerHelper(null)),
             };
             var statsRouter = new StatsRouter(serializers, bufferBuilder, null);
-            using (var statsBufferize = new StatsBufferize(statsRouter, 10, null, TimeSpan.Zero, null))
+            using (var statsBufferize = new StatsBufferize(statsRouter, 10, null, TimeSpan.Zero, Tools.ExceptionHandler))
             {
                 var stats = new Stats { Kind = StatsKind.Event };
                 stats.Event.Text = "test";

--- a/tests/StatsdClient.Tests/DogStatsdServiceMetricsTests.cs
+++ b/tests/StatsdClient.Tests/DogStatsdServiceMetricsTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using NUnit.Framework;
 using StatsdClient;
 using Tests.Utils;

--- a/tests/StatsdClient.Tests/PoolTests.cs
+++ b/tests/StatsdClient.Tests/PoolTests.cs
@@ -37,7 +37,7 @@ namespace Tests
         private class PoolObject : AbstractPoolObject
         {
             public PoolObject(IPool p)
-            : base(p)
+            : base(p, null)
             {
             }
 

--- a/tests/StatsdClient.Tests/PoolTests.cs
+++ b/tests/StatsdClient.Tests/PoolTests.cs
@@ -1,6 +1,7 @@
 using System;
 using NUnit.Framework;
 using StatsdClient.Utils;
+using Tests.Utils;
 
 namespace Tests
 {
@@ -37,7 +38,7 @@ namespace Tests
         private class PoolObject : AbstractPoolObject
         {
             public PoolObject(IPool p)
-            : base(p, null)
+            : base(p, Tools.ExceptionHandler)
             {
             }
 

--- a/tests/StatsdClient.Tests/StatsdBuilderTests.cs
+++ b/tests/StatsdClient.Tests/StatsdBuilderTests.cs
@@ -132,7 +132,8 @@ namespace StatsdClient.Tests
                 It.IsAny<StatsRouter>(),
                 conf.MaxMetricsInAsyncQueue,
                 conf.MaxBlockDuration,
-                conf.DurationBeforeSendingNotFullBuffer));
+                conf.DurationBeforeSendingNotFullBuffer,
+                null));
             _mock.Verify(
                 m => m.CreateStatsRouter(
                 It.IsAny<Serializers>(),
@@ -152,7 +153,8 @@ namespace StatsdClient.Tests
                 It.IsAny<StatsRouter>(),
                 It.IsAny<int>(),
                 null,
-                It.IsAny<TimeSpan>()));
+                It.IsAny<TimeSpan>(),
+                null));
             _mock.Verify(
                 m => m.CreateStatsRouter(
                 It.IsAny<Serializers>(),
@@ -189,7 +191,8 @@ namespace StatsdClient.Tests
                 It.Is<string>(v => !string.IsNullOrEmpty(v)),
                 conf.TelemetryFlushInterval.Value,
                 It.IsAny<ITransport>(),
-                It.Is<string[]>(tags => Enumerable.SequenceEqual(tags, expectedTags))));
+                It.Is<string[]>(tags => Enumerable.SequenceEqual(tags, expectedTags)),
+                null));
         }
 
         [Test]
@@ -296,7 +299,7 @@ namespace StatsdClient.Tests
 
         private void BuildStatsData(StatsdConfig config)
         {
-            var buildStatsData = _statsdBuilder.BuildStatsData(config);
+            var buildStatsData = _statsdBuilder.BuildStatsData(config, null);
             buildStatsData.Dispose();
         }
     }

--- a/tests/StatsdClient.Tests/StatsdBuilderTests.cs
+++ b/tests/StatsdClient.Tests/StatsdBuilderTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using StatsdClient.Aggregator;
 using StatsdClient.Bufferize;
 using StatsdClient.Transport;
+using Tests.Utils;
 
 namespace StatsdClient.Tests
 {
@@ -133,7 +134,7 @@ namespace StatsdClient.Tests
                 conf.MaxMetricsInAsyncQueue,
                 conf.MaxBlockDuration,
                 conf.DurationBeforeSendingNotFullBuffer,
-                null));
+                Tools.ExceptionHandler));
             _mock.Verify(
                 m => m.CreateStatsRouter(
                 It.IsAny<Serializers>(),
@@ -154,7 +155,7 @@ namespace StatsdClient.Tests
                 It.IsAny<int>(),
                 null,
                 It.IsAny<TimeSpan>(),
-                null));
+                Tools.ExceptionHandler));
             _mock.Verify(
                 m => m.CreateStatsRouter(
                 It.IsAny<Serializers>(),
@@ -192,7 +193,7 @@ namespace StatsdClient.Tests
                 conf.TelemetryFlushInterval.Value,
                 It.IsAny<ITransport>(),
                 It.Is<string[]>(tags => Enumerable.SequenceEqual(tags, expectedTags)),
-                null));
+                Tools.ExceptionHandler));
         }
 
         [Test]
@@ -299,7 +300,7 @@ namespace StatsdClient.Tests
 
         private void BuildStatsData(StatsdConfig config)
         {
-            var buildStatsData = _statsdBuilder.BuildStatsData(config, null);
+            var buildStatsData = _statsdBuilder.BuildStatsData(config, Tools.ExceptionHandler);
             buildStatsData.Dispose();
         }
     }

--- a/tests/StatsdClient.Tests/StatsdConfigurationTests.cs
+++ b/tests/StatsdClient.Tests/StatsdConfigurationTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using StatsdClient;
 using Tests.Helpers;
@@ -15,7 +14,9 @@ namespace Tests
         {
             var sut = CreateSut();
             StatsdConfig metricsConfig = null;
-            Assert.Throws<ArgumentNullException>(() => sut.Configure(metricsConfig));
+            Exception exception = null;
+            Assert.False(sut.Configure(metricsConfig, e => exception = e));
+            Assert.True(exception is ArgumentNullException);
         }
 
         [Test]
@@ -23,7 +24,9 @@ namespace Tests
         {
             var sut = CreateSut();
             var metricsConfig = new StatsdConfig { };
-            Assert.Throws<ArgumentNullException>(() => sut.Configure(metricsConfig));
+            Exception exception = null;
+            Assert.False(sut.Configure(metricsConfig, e => exception = e));
+            Assert.True(exception is ArgumentNullException);
         }
 
         [Test]
@@ -35,7 +38,7 @@ namespace Tests
                 {
                     StatsdServerName = "127.0.0.1",
                 };
-                sut.Configure(metricsConfig);
+                Assert.True(sut.Configure(metricsConfig));
                 TestReceive("127.0.0.1", 8125, "test", "test:1|c\n", sut);
             }
         }
@@ -85,7 +88,9 @@ namespace Tests
 
                 sut.Configure(metricsConfig);
 
-                Assert.Throws<InvalidOperationException>(() => sut.Configure(metricsConfig));
+                Exception exception = null;
+                Assert.False(sut.Configure(metricsConfig, e => exception = e));
+                Assert.True(exception is InvalidOperationException);
             }
         }
 

--- a/tests/StatsdClient.Tests/TelemetryTests.cs
+++ b/tests/StatsdClient.Tests/TelemetryTests.cs
@@ -27,7 +27,8 @@ namespace Tests
                 "1.0.0.0",
                 TimeSpan.FromHours(1),
                 transport.Object,
-                new string[] { "globalTagKey:globalTagValue" });
+                new string[] { "globalTagKey:globalTagValue" },
+                null);
         }
 
         [TearDown]

--- a/tests/StatsdClient.Tests/TelemetryTests.cs
+++ b/tests/StatsdClient.Tests/TelemetryTests.cs
@@ -6,6 +6,7 @@ using Moq;
 using NUnit.Framework;
 using StatsdClient;
 using StatsdClient.Transport;
+using Tests.Utils;
 
 namespace Tests
 {
@@ -28,7 +29,7 @@ namespace Tests
                 TimeSpan.FromHours(1),
                 transport.Object,
                 new string[] { "globalTagKey:globalTagValue" },
-                null);
+                Tools.ExceptionHandler);
         }
 
         [TearDown]

--- a/tests/StatsdClient.Tests/Worker/AsynchronousWorkerTests.cs
+++ b/tests/StatsdClient.Tests/Worker/AsynchronousWorkerTests.cs
@@ -120,6 +120,7 @@ namespace Tests
                 _waiter.Object,
                 workerThreadCount,
                 10,
+                null,
                 null);
             _workers.Add(worker);
             return worker;

--- a/tests/StatsdClient.Tests/Worker/AsynchronousWorkerTests.cs
+++ b/tests/StatsdClient.Tests/Worker/AsynchronousWorkerTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
 using StatsdClient.Worker;
+using Tests.Utils;
 
 namespace Tests
 {
@@ -121,7 +122,7 @@ namespace Tests
                 workerThreadCount,
                 10,
                 null,
-                null);
+                Tools.ExceptionHandler);
             _workers.Add(worker);
             return worker;
         }
@@ -140,7 +141,7 @@ namespace Tests
                     1,
                     10,
                     null,
-                    null);
+                    Tools.ExceptionHandler);
             }
         }
 #endif

--- a/tests/StatsdClient.Tests/Worker/AsynchronousWorkerTests.cs
+++ b/tests/StatsdClient.Tests/Worker/AsynchronousWorkerTests.cs
@@ -139,6 +139,7 @@ namespace Tests
                     new Mock<IWaiter>().Object,
                     1,
                     10,
+                    null,
                     null);
             }
         }

--- a/tests/StatsdClient.Tests/utils/Tools.cs
+++ b/tests/StatsdClient.Tests/utils/Tools.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Tests.Utils
+{
+    internal static class Tools
+    {
+        public static void ExceptionHandler(Exception e)
+        {
+            // In unit tests, rethrow the exception
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
`DogStatsdService.Configure` now takes an optional exception handler which is called when an error occurs. Previously, exceptions were logged using `Debug.WriteLine`. In addition, `DogStatsdService.Configure` doesn't throw an exception when an error occurs but returns false and the error is reported to the error handler.

Note: This an API breaking changes.
