### PR TITLE
Remove support for old frameworks

### DIFF
--- a/BuildWarningAsError.ps1
+++ b/BuildWarningAsError.ps1
@@ -1,7 +1,7 @@
 # When there are only warnings, the exit code is 0.
 # See https://github.com/dotnet/installer/issues/1708.
 
-# Ignore warning NETSDK1138: The target framework 'netcoreapp2.0' is out of support and will not receive security updates in the future
+# Ignore warning NETSDK1138: The target framework 'netcoreapp2.1' is out of support and will not receive security updates in the future
 dotnet build -warnaserror -warnAsMessage:NETSDK1138 *> build.txt
 Get-Content build.txt
 $noError = Select-String -Path build.txt -pattern "0 Error\(s\)"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 3.0.0.{build}
-os: Visual Studio 2019
+os: Visual Studio 2022
 configuration: Release
 
 before_build:

--- a/benchmarks/StatsdClient.Benchmarks/StatsdClient.Benchmarks.csproj
+++ b/benchmarks/StatsdClient.Benchmarks/StatsdClient.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>StatsdClient.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/StatsdClient/Bufferize/StatsBufferizeFactory.cs
+++ b/src/StatsdClient/Bufferize/StatsBufferizeFactory.cs
@@ -48,11 +48,7 @@ namespace StatsdClient.Bufferize
 
         public ITransport CreateNamedPipeTransport(string pipeName)
         {
-#if NAMED_PIPE_AVAILABLE
             return new NamedPipeTransport(pipeName);
-#else
-            throw new NotSupportedException("Named pipes are not supported on this .NET framework.");
-#endif
         }
     }
 }

--- a/src/StatsdClient/Serializer/MetricSerializer.cs
+++ b/src/StatsdClient/Serializer/MetricSerializer.cs
@@ -61,7 +61,7 @@ namespace StatsdClient
             var intValue = (int)v;
             var provider = CultureInfo.InvariantCulture;
 
-#if NETSTANDARD2_1
+#if HAS_SPAN
             Span<char> span = numericBuffer;
             bool tryFormatSuccess;
             int charsWritten;

--- a/src/StatsdClient/StatsdClient.csproj
+++ b/src/StatsdClient/StatsdClient.csproj
@@ -16,6 +16,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <!-- See https://learn.microsoft.com/en-us/dotnet/api/system.span-1?view=net-6.0 -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net6.0' ">
+    <DefineConstants>HAS_SPAN</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">

--- a/src/StatsdClient/StatsdClient.csproj
+++ b/src/StatsdClient/StatsdClient.csproj
@@ -16,14 +16,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard1.3' ">
-    <DefineConstants>NAMED_PIPE_AVAILABLE</DefineConstants>
-  </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="System.Net.NameResolution">
-      <Version>4.3.0</Version>
-    </PackageReference>
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">

--- a/src/StatsdClient/StatsdClient.csproj
+++ b/src/StatsdClient/StatsdClient.csproj
@@ -4,7 +4,7 @@
     <PackageId>DogStatsD-CSharp-Client</PackageId>
     <Description>A DogStatsD client for C#. DogStatsD is an extension of the StatsD metric server for use with Datadog. For more information visit http://datadoghq.com.</Description>
     <Authors>Datadog</Authors>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;net45;net461</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>    
     <PackageVersion>7.0.1</PackageVersion>
     <Version>7.0.0</Version>
     <PackageLicenseUrl>https://github.com/DataDog/dogstatsd-csharp-client/blob/master/MIT-LICENCE.md</PackageLicenseUrl>

--- a/src/StatsdClient/StatsdUDP.cs
+++ b/src/StatsdClient/StatsdUDP.cs
@@ -1,10 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Sockets;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace StatsdClient
 {
@@ -18,11 +13,8 @@ namespace StatsdClient
             if (!isValidIPAddress)
             {
                 ipAddress = null;
-#if NET45
-                IPAddress[] addressList = Dns.GetHostEntry(name).AddressList;
-#else
                 IPAddress[] addressList = Dns.GetHostEntryAsync(name).Result.AddressList;
-#endif
+
                 // The IPv4 address is usually the last one, but not always
                 for (int positionToTest = addressList.Length - 1; positionToTest >= 0; --positionToTest)
                 {

--- a/src/StatsdClient/Transport/NamedPipeTransport.cs
+++ b/src/StatsdClient/Transport/NamedPipeTransport.cs
@@ -1,4 +1,3 @@
-#if NAMED_PIPE_AVAILABLE
 using System;
 using System.IO;
 using System.IO.Pipes;
@@ -100,4 +99,3 @@ namespace StatsdClient.Transport
         }
     }
 }
-#endif

--- a/src/StatsdClient/Transport/NamedPipeTransport.cs
+++ b/src/StatsdClient/Transport/NamedPipeTransport.cs
@@ -86,8 +86,9 @@ namespace StatsdClient.Transport
             {
                 ioException = true;
             }
-            catch (AggregateException e) // dotnet6.0 raises AggregateException when an IOException occurs. 
+            catch (AggregateException e)
             {
+                // dotnet6.0 raises AggregateException when an IOException occurs.
                 e.Handle(ex =>
                 {
                     if (ex is IOException)

--- a/src/StatsdClient/Worker/Waiter.cs
+++ b/src/StatsdClient/Worker/Waiter.cs
@@ -6,11 +6,7 @@ namespace StatsdClient.Worker
     {
         public void Wait(TimeSpan duration)
         {
-#if NETSTANDARD1_3
-            System.Threading.Tasks.Task.Delay(duration).Wait();
-#else
             System.Threading.Thread.Sleep(duration);
-#endif
         }
     }
 }

--- a/tests/StatsdClient.Tests/CommandIntegrationTests.cs
+++ b/tests/StatsdClient.Tests/CommandIntegrationTests.cs
@@ -230,7 +230,7 @@ namespace Tests
         public void Gauge_double_rounding()
         {
             _dogStatsdService.Gauge("gauge", 1.0 / 9);
-#if NET5_0
+#if NEW_DOUBLE_FORMATTING
             // double formating changed in .NET Core 3.0
             AssertWasReceived("gauge:0.1111111111111111|g");
 #else

--- a/tests/StatsdClient.Tests/StatsdClient.Tests.csproj
+++ b/tests/StatsdClient.Tests/StatsdClient.Tests.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
-    <TargetFrameworks>net461;net6.0</TargetFrameworks>
+  <PropertyGroup>
+    <!-- 
+      Test all target frameworks from src/StatsdClient/StatsdClient.csproj
+        - net461 -> net461
+        - netcoreapp2.1 -> netstandard2.0
+        - netcoreapp3.1 -> netcoreapp3.1 
+      -  net6.0 -> net6.0
+    -->
+    <TargetFrameworks>net461;netcoreapp2.1;net5.0;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>StatsdClient.snk</AssemblyOriginatorKeyFile>
     <NoWarn>0618</NoWarn>
@@ -13,7 +20,7 @@
   </PropertyGroup>
 
   <!-- See https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/numeric-format-parsing-handles-higher-precision -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net5.0' ">
     <DefineConstants>$(DefineConstants);NEW_DOUBLE_FORMATTING</DefineConstants>
   </PropertyGroup>
 

--- a/tests/StatsdClient.Tests/StatsdClient.Tests.csproj
+++ b/tests/StatsdClient.Tests/StatsdClient.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net6.0</TargetFrameworks>
+    <!-- Use net5.0 and not net6.0 as net6.0 doesn't support Unix Domain socket on Windows -->
+    <TargetFrameworks>net461;net5.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>StatsdClient.snk</AssemblyOriginatorKeyFile>
     <NoWarn>0618</NoWarn>
@@ -13,7 +14,7 @@
   </PropertyGroup>
 
   <!-- See https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/numeric-format-parsing-handles-higher-precision -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <DefineConstants>NEW_DOUBLE_FORMATTING</DefineConstants>
   </PropertyGroup>
 

--- a/tests/StatsdClient.Tests/StatsdClient.Tests.csproj
+++ b/tests/StatsdClient.Tests/StatsdClient.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net461</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>StatsdClient.snk</AssemblyOriginatorKeyFile>
     <NoWarn>0618</NoWarn>
@@ -11,6 +11,12 @@
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
     <DefineConstants>OS_WINDOWS</DefineConstants>
   </PropertyGroup>
+
+  <!-- See https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/numeric-format-parsing-handles-higher-precision -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <DefineConstants>NEW_DOUBLE_FORMATTING</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Moq" Version="4.7.137" />

--- a/tests/StatsdClient.Tests/StatsdClient.Tests.csproj
+++ b/tests/StatsdClient.Tests/StatsdClient.Tests.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <!-- See https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/numeric-format-parsing-handles-higher-precision -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <DefineConstants>$(DefineConstants);NEW_DOUBLE_FORMATTING</DefineConstants>
   </PropertyGroup>
 

--- a/tests/StatsdClient.Tests/StatsdClient.Tests.csproj
+++ b/tests/StatsdClient.Tests/StatsdClient.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <!-- Use net5.0 and not net6.0 as net6.0 doesn't support Unix Domain socket on Windows -->
-    <TargetFrameworks>net461;net5.0</TargetFrameworks>
+  <PropertyGroup>    
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>StatsdClient.snk</AssemblyOriginatorKeyFile>
     <NoWarn>0618</NoWarn>
@@ -15,7 +14,7 @@
 
   <!-- See https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/numeric-format-parsing-handles-higher-precision -->
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <DefineConstants>NEW_DOUBLE_FORMATTING</DefineConstants>
+    <DefineConstants>$(DefineConstants);NEW_DOUBLE_FORMATTING</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR removes support for old frameworks.

Before
```
  <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;net45;net461</TargetFrameworks>
```
After
```
    <TargetFrameworks>net461;netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks> 
```

Align with [dd-trace-dotnet](https://github.com/DataDog/dd-trace-dotnet/blob/23ebd0767fa745917c1b1a8147489161ebbbd5a2/tracer/src/Directory.Build.props#L5).