### PR TITLE
Add `timestamp` arguments to `Increment` and `Decrement` methods

### DIFF
--- a/src/StatsdClient/DogStatsdService.cs
+++ b/src/StatsdClient/DogStatsdService.cs
@@ -106,9 +106,10 @@ namespace StatsdClient
         /// <param name="value">The amount of increment.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        public void Increment(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null)
+        /// <param name="timestamp">BETA - Please contact our support team for more information to use this feature: https://www.datadoghq.com/support/ - Timestamp at which the counter has been seen with the given value. This value is sent without any aggregation.</param>
+        public void Increment(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null)
         {
-            _metricsSender?.SendMetric(MetricType.Count, statName, value, sampleRate, tags);
+            _metricsSender?.SendMetric(MetricType.Count, statName, value, sampleRate, tags, timestamp);
         }
 
         /// <summary>
@@ -118,9 +119,10 @@ namespace StatsdClient
         /// <param name="value">The amount of decrement.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        public void Decrement(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null)
+        /// <param name="timestamp">BETA - Please contact our support team for more information to use this feature: https://www.datadoghq.com/support/ - Timestamp at which the counter has been seen with the given value. This value is sent without any aggregation.</param>
+        public void Decrement(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null)
         {
-            _metricsSender?.SendMetric(MetricType.Count, statName, -value, sampleRate, tags);
+            _metricsSender?.SendMetric(MetricType.Count, statName, -value, sampleRate, tags, timestamp);
         }
 
         /// <summary>
@@ -145,7 +147,7 @@ namespace StatsdClient
         /// <param name="tags">Array of tags to be added to the data.</param>
         public void Histogram(string statName, double value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.SendMetric(MetricType.Histogram, statName, value, sampleRate, tags);
+            _metricsSender?.SendMetric(MetricType.Histogram, statName, value, sampleRate, tags, null);
         }
 
         /// <summary>
@@ -157,7 +159,7 @@ namespace StatsdClient
         /// <param name="tags">Array of tags to be added to the data.</param>
         public void Distribution(string statName, double value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.SendMetric(MetricType.Distribution, statName, value, sampleRate, tags);
+            _metricsSender?.SendMetric(MetricType.Distribution, statName, value, sampleRate, tags, null);
         }
 
         /// <summary>
@@ -195,7 +197,7 @@ namespace StatsdClient
         /// <param name="tags">Array of tags to be added to the data.</param>
         public void Timer(string statName, double value, double sampleRate = 1.0, string[] tags = null)
         {
-            _metricsSender?.SendMetric(MetricType.Timing, statName, value, sampleRate, tags);
+            _metricsSender?.SendMetric(MetricType.Timing, statName, value, sampleRate, tags, null);
         }
 
         /// <summary>

--- a/src/StatsdClient/Dogstatsd.cs
+++ b/src/StatsdClient/Dogstatsd.cs
@@ -105,8 +105,9 @@ namespace StatsdClient
         /// <param name="value">The amount of increment.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        public static void Increment(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null) =>
-            _dogStatsdService.Increment(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
+        /// <param name="timestamp">BETA - Please contact our support team for more information to use this feature: https://www.datadoghq.com/support/ - Timestamp at which the counter has been seen with the given value. This value is sent without any aggregation.</param>
+        public static void Increment(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null) =>
+            _dogStatsdService.Increment(statName: statName, value: value, sampleRate: sampleRate, tags: tags, timestamp: timestamp);
 
         /// <summary>
         /// Decrements the specified counter.
@@ -115,8 +116,9 @@ namespace StatsdClient
         /// <param name="value">The amount of decrement.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        public static void Decrement(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null) =>
-            _dogStatsdService.Decrement(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
+        /// <param name="timestamp">BETA - Please contact our support team for more information to use this feature: https://www.datadoghq.com/support/ - Timestamp at which the counter has been seen with the given value. This value is sent without any aggregation.</param>
+        public static void Decrement(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null) =>
+            _dogStatsdService.Decrement(statName: statName, value: value, sampleRate: sampleRate, tags: tags, timestamp: timestamp);
 
         /// <summary>
         /// Records the latest fixed value for the specified named gauge.

--- a/src/StatsdClient/IDogStatsd.cs
+++ b/src/StatsdClient/IDogStatsd.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace StatsdClient
 {
@@ -41,7 +41,8 @@ namespace StatsdClient
         /// <param name="value">The amount of decrement.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        void Decrement(string statName, int value = 1, double sampleRate = 1, params string[] tags);
+        /// <param name="timestamp">BETA - Please contact our support team for more information to use this feature: https://www.datadoghq.com/support/ - Timestamp at which the counter has been seen with the given value. This value is sent without any aggregation.</param>
+        void Decrement(string statName, int value = 1, double sampleRate = 1, string[] tags = null, DateTimeOffset? timestamp = null);
 
         /// <summary>
         /// Records an event.
@@ -101,7 +102,8 @@ namespace StatsdClient
         /// <param name="value">The amount of increment.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        void Increment(string statName, int value = 1, double sampleRate = 1, string[] tags = null);
+        /// <param name="timestamp">BETA - Please contact our support team for more information to use this feature: https://www.datadoghq.com/support/ - Timestamp at which the counter has been seen with the given value. This value is sent without any aggregation.</param>
+        void Increment(string statName, int value = 1, double sampleRate = 1, string[] tags = null, DateTimeOffset? timestamp = null);
 
         /// <summary>
         /// Records a value for the specified set.

--- a/src/StatsdClient/MetricsSender.cs
+++ b/src/StatsdClient/MetricsSender.cs
@@ -65,7 +65,7 @@ namespace StatsdClient
             }
         }
 
-        public void SendMetric(MetricType metricType, string name, double value, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null)
+        public void SendMetric(MetricType metricType, string name, double value, double sampleRate, string[] tags, DateTimeOffset? timestamp)
         {
             if (metricType == MetricType.Set)
             {
@@ -129,7 +129,7 @@ namespace StatsdClient
             finally
             {
                 stopwatch.Stop();
-                SendMetric(MetricType.Timing, statName, stopwatch.ElapsedMilliseconds(), sampleRate, tags);
+                SendMetric(MetricType.Timing, statName, stopwatch.ElapsedMilliseconds(), sampleRate, tags, null);
             }
         }
 


### PR DESCRIPTION
This PR adds a `timestamp` argument to `Increment` and `Decrement` methods. See https://github.com/DataDog/dogstatsd-csharp-client/pull/185 for more context.

Note: This PR also removes `params` for tags in `IDogStatsd.Decrement`.