### PR TITLE
Improve readme examples that use `Configure`

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ var dogstatsdConfig = new StatsdConfig
     StatsdPort = 8125,
 };
 
-if (!service.Configure(dogstatsdConfig))
+if (!DogStatsd.Configure(dogstatsdConfig))
     throw new InvalidOperationException("Cannot initialize DogstatsD. Set optionalExceptionHandler argument in the `Configure` method for more information.");
 DogStatsd.Increment("example_metric.increment", tags: new[] { "environment:dev" });
 DogStatsd.Decrement("example_metric.decrement", tags: new[] { "environment:dev" });

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ var dogstatsdConfig = new StatsdConfig
 };
 
 using (var service = new DogStatsdService())
-{
-    service.Configure(dogstatsdConfig);
+{    
+    if (!service.Configure(dogstatsdConfig))
+        throw new InvalidOperationException("Cannot initialize DogstatsD. Set optionalExceptionHandler argument in the `Configure` method for more information.");
 }
 ```
 
@@ -67,7 +68,9 @@ var dogstatsdConfig = new StatsdConfig
 
 using (var service = new DogStatsdService())
 {
-    service.Configure(dogstatsdConfig);
+    if (!service.Configure(dogstatsdConfig))
+        throw new InvalidOperationException("Cannot initialize DogstatsD. Set optionalExceptionHandler argument in the `Configure` method for more information.");
+                    
     service.Increment("example_metric.increment", tags: new[] { "environment:dev" });
     service.Decrement("example_metric.decrement", tags: new[] { "environment:dev" });
     service.Counter("example_metric.count", 2, tags: new[] { "environment:dev" });
@@ -97,7 +100,8 @@ var dogstatsdConfig = new StatsdConfig
     StatsdPort = 8125,
 };
 
-DogStatsd.Configure(dogstatsdConfig);
+if (!service.Configure(dogstatsdConfig))
+    throw new InvalidOperationException("Cannot initialize DogstatsD. Set optionalExceptionHandler argument in the `Configure` method for more information.");
 DogStatsd.Increment("example_metric.increment", tags: new[] { "environment:dev" });
 DogStatsd.Decrement("example_metric.decrement", tags: new[] { "environment:dev" });
 DogStatsd.Counter("example_metric.count", 2, tags: new[] { "environment:dev" });

--- a/tests/StatsdClient.Tests/StatsdClient.Tests.csproj
+++ b/tests/StatsdClient.Tests/StatsdClient.Tests.csproj
@@ -5,8 +5,8 @@
       Test all target frameworks from src/StatsdClient/StatsdClient.csproj
         - net461 -> net461
         - netcoreapp2.1 -> netstandard2.0
-        - netcoreapp3.1 -> netcoreapp3.1 
-      -  net6.0 -> net6.0
+        - net5.0 -> netcoreapp3.1
+        - net6.0 -> net6.0
     -->
     <TargetFrameworks>net461;netcoreapp2.1;net5.0;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Improve readme `Configure` examples as `Configure` method doesn't throw an exception anymore.