### PR TITLE
Replace the spinlock by a monitor

### DIFF
--- a/src/StatsdClient/Transport/NamedPipeTransport.cs
+++ b/src/StatsdClient/Transport/NamedPipeTransport.cs
@@ -67,8 +67,9 @@ namespace StatsdClient.Transport
             catch (IOException)
             {
             }
-            catch (AggregateException e) when (e.InnerException is IOException) // dotnet6.0 raises AggregateException when an IOException occurs.
+            catch (AggregateException e) when (e.InnerException is IOException)
             {
+                // dotnet6.0 raises AggregateException when an IOException occurs.
             }
 
             // When the server disconnects, IOException is raised with the message "Pipe is broken".


### PR DESCRIPTION
Spinlock shouldn't be used to protect an I/O operation. With the default timeout, the operation can take up to 2 seconds, which ends up using a lot of CPU. This PR replaces it with a Monitor.

Also some minor cleanup.