### PR TITLE
chore(ci): get unit tests running in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,5 +50,6 @@ jobs:
                       3.0.x
                       3.1.x
                       5.0.x
+                      7.0.x
             - name: Run tests
               run: dotnet test --blame-hang --blame-hang-dump-type none --blame-hang-timeout 60s -- tests/StatsdClient.Tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
         branches: [master]
 
 jobs:
-    analyze:
+    unit-tests-linux:
         name: Tests (Linux)
         runs-on: ubuntu-latest
         permissions:
@@ -29,5 +29,26 @@ jobs:
                       7.0.x
                       8.0.x
                       9.0.x
+            - name: Run tests
+              run: dotnet test tests/StatsdClient.Tests/
+    unit-tests-windows:
+        name: Tests (Windows)
+        runs-on: windows-latest
+        permissions:
+            actions: read
+            contents: read
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+            - name: Setup .NET Core
+              uses: actions/setup-dotnet@v4
+              with:
+                  # Windows runner images have more versions of .NET Core pre-installed than Linux.
+                  dotnet-version: |
+                      2.1.x
+                      3.0.x
+                      3.1.x
+                      5.0.x
             - name: Run tests
               run: dotnet test tests/StatsdClient.Tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
             - name: Setup .NET Core
               uses: actions/setup-dotnet@v4
               with:
+                  cache: true
                   dotnet-version: |
                       2.1.x
                       3.0.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: "Test"
+
+on:
+    push:
+        branches: [master]
+    pull_request:
+        branches: [master]
+
+jobs:
+    analyze:
+        name: Tests (Linux)
+        runs-on: ubuntu-latest
+        permissions:
+            actions: read
+            contents: read
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+            - name: Setup .NET Core
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: |
+                      2.1.x
+                      3.0.x
+                      3.1.x
+                      5.0.x
+                      6.0.x
+                      7.0.x
+                      8.0.x
+                      9.0.x
+            - name: Run tests
+              run: dotnet test tests/StatsdClient.Tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
                       8.0.x
                       9.0.x
             - name: Run tests
-              run: dotnet test tests/StatsdClient.Tests/
+              run: dotnet test --blame-hang --blame-hang-dump-type none --blame-hang-timeout 60s -- tests/StatsdClient.Tests/
     unit-tests-windows:
         name: Tests (Windows)
         runs-on: windows-latest
@@ -51,4 +51,4 @@ jobs:
                       3.1.x
                       5.0.x
             - name: Run tests
-              run: dotnet test tests/StatsdClient.Tests/
+              run: dotnet test --blame-hang --blame-hang-dump-type none --blame-hang-timeout 60s -- tests/StatsdClient.Tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
             - name: Setup .NET Core
               uses: actions/setup-dotnet@v4
               with:
-                  cache: true
                   dotnet-version: |
                       2.1.x
                       3.0.x

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Grab the [package from NuGet](https://nuget.org/packages/DogStatsD-CSharp-Client
 ### Platforms
 
 DogStatsD-CSharp-Client supports the following platforms:
-* .NET Standard 1.3 or greater
-* .NET Core 1.0 or greater
-* .NET Framework 4.5.1 or greater
+* .NET Standard 2.0 or greater
+* .NET Core 2.0 or greater
+* .NET Framework 4.6.1 or greater
 
 ## Configuration
 
@@ -34,7 +34,7 @@ var dogstatsdConfig = new StatsdConfig
 };
 
 using (var service = new DogStatsdService())
-{    
+{
     if (!service.Configure(dogstatsdConfig))
         throw new InvalidOperationException("Cannot initialize DogstatsD. Set optionalExceptionHandler argument in the `Configure` method for more information.");
 }
@@ -70,7 +70,7 @@ using (var service = new DogStatsdService())
 {
     if (!service.Configure(dogstatsdConfig))
         throw new InvalidOperationException("Cannot initialize DogstatsD. Set optionalExceptionHandler argument in the `Configure` method for more information.");
-                    
+
     service.Increment("example_metric.increment", tags: new[] { "environment:dev" });
     service.Decrement("example_metric.decrement", tags: new[] { "environment:dev" });
     service.Counter("example_metric.count", 2, tags: new[] { "environment:dev" });
@@ -84,7 +84,7 @@ using (var service = new DogStatsdService())
         service.Histogram("example_metric.histogram", random.Next(20), tags: new[] { "environment:dev" });
         System.Threading.Thread.Sleep(random.Next(10000));
     }
-}  
+}
 ```
 
 Here is another example to submit different kinds of metrics with `DogStatsd`.
@@ -115,7 +115,7 @@ for (int i = 0; i < 10; i++)
     DogStatsd.Histogram("example_metric.histogram", random.Next(20), tags: new[] { "environment:dev" });
     System.Threading.Thread.Sleep(random.Next(10000));
 }
-  
+
 DogStatsd.Dispose(); // Flush all metrics not yet sent
 ```
 
@@ -154,26 +154,26 @@ You can use unix domain socket protocol by setting `StatsdServerName` property t
 
 ``` C#
 var dogstatsdConfig = new StatsdConfig
-{    
-    StatsdServerName = "unix:///tmp/dsd.socket"  
+{
+    StatsdServerName = "unix:///tmp/dsd.socket"
 };
 ```
 
 The property `StatsdMaxUnixDomainSocketPacketSize` of `StatsdConfig` defines the maximum size of the payload. Values higher than 8196 bytes are ignored.
 
 **The feature is not supported on Windows platform**.
-Windows has support for [unix domain socket](https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/), but not for unix domain socket of type Dgram (`SocketType.Dgram`). 
+Windows has support for [unix domain socket](https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/), but not for unix domain socket of type Dgram (`SocketType.Dgram`).
 
 On MacOS Mojave, setting more than `2048` bytes for `StatsdMaxUnixDomainSocketPacketSize` is experimental.
 
 ## Client side aggregation
 
-By default, metrics for basic types (gauges, counts, sets) are aggregated before they are sent. For example, instead of sending 3 times `my_metric:10|c|#tag1:value`, DogStatsD client sends `my_metric:30|c|#tag1:value` once. 
+By default, metrics for basic types (gauges, counts, sets) are aggregated before they are sent. For example, instead of sending 3 times `my_metric:10|c|#tag1:value`, DogStatsD client sends `my_metric:30|c|#tag1:value` once.
 For more technical details about how client-side aggregation works see #134.
 
 Enabling client-side aggregation has the benefit of reducing the network usage and also reducing the load for DogStatsD server (Datadog Agent).
 
-When an application sends a lot of different contexts but each context appears with a very low frequency, enabling client-side aggregation may take more memory and more CPU. A context identifies a metric name, a tag set and a metric type. The metric `datadog.dogstatsd.client.aggregated_context` reported by DogStatsD C# client counts the number of contexts in memory used for client-side aggregation. There is also the metric `datadog.dogstatsd.client.metrics_by_type` that represents the number of metrics submitted by the client before aggregation. 
+When an application sends a lot of different contexts but each context appears with a very low frequency, enabling client-side aggregation may take more memory and more CPU. A context identifies a metric name, a tag set and a metric type. The metric `datadog.dogstatsd.client.aggregated_context` reported by DogStatsD C# client counts the number of contexts in memory used for client-side aggregation. There is also the metric `datadog.dogstatsd.client.metrics_by_type` that represents the number of metrics submitted by the client before aggregation.
 
 ### Configuration
 

--- a/tests/StatsdClient.Tests/StatsdClient.Tests.csproj
+++ b/tests/StatsdClient.Tests/StatsdClient.Tests.csproj
@@ -1,14 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- 
-      Test all target frameworks from src/StatsdClient/StatsdClient.csproj
-        - net461 -> net461
-        - netcoreapp2.1 -> netstandard2.0
-        - net5.0 -> netcoreapp3.1
-        - net6.0 -> net6.0
-    -->
-    <TargetFrameworks>net461;netcoreapp2.1;net5.0;net6.0</TargetFrameworks>
+    <!-- only run .NET Framework tests on Windows -->
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net48;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+
+    <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp3.0) -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+
+    <!-- Stop NuGet from complaining about vulnerable packages -->
+    <NuGetAudit>false</NuGetAudit>
+
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>StatsdClient.snk</AssemblyOriginatorKeyFile>
     <NoWarn>0618</NoWarn>


### PR DESCRIPTION
## Context

This PR adds a new Github Actions workflow to start running unit tests in CI as part of PRs targeting `master` and pushes to `master` itself.

The unit tests run on both Linux (Ubuntu) and Windows targeting a more explicit list of targets. This matches the support matrix we have for `dd-trace-dotnet`, which we're choosing to match here as they should be our gold standard in what to support.

This PR is _not_ meant to get all of the tests running, but to establish the running of tests in CI so we can observe improvements/fixes to tests as we address the actual failures.