### PR TITLE
chore(tests): fix a number of broken tests

### DIFF
--- a/tests/StatsdClient.Tests/CommandIntegrationTests.cs
+++ b/tests/StatsdClient.Tests/CommandIntegrationTests.cs
@@ -230,11 +230,10 @@ namespace Tests
         public void Gauge_double_rounding()
         {
             _dogStatsdService.Gauge("gauge", 1.0 / 9);
-#if NEW_DOUBLE_FORMATTING
-            // double formating changed in .NET Core 3.0
-            AssertWasReceived("gauge:0.1111111111111111|g");
-#else
+#if OLD_DOUBLE_FORMATTING
             AssertWasReceived("gauge:0.111111111111111|g");
+#else
+            AssertWasReceived("gauge:0.1111111111111111|g");
 #endif
         }
 

--- a/tests/StatsdClient.Tests/DogStatsdServiceConfigurationTest.cs
+++ b/tests/StatsdClient.Tests/DogStatsdServiceConfigurationTest.cs
@@ -11,27 +11,6 @@ namespace Tests
     public class DogStatsdServiceConfigurationTest
     {
         [Test]
-        public void Default_port_is_8125()
-        {
-            using (var nonStaticServiceInstance = new DogStatsdService())
-            {
-                var metricsConfig = new StatsdConfig
-                {
-                    StatsdServerName = "127.0.0.1",
-                };
-
-                nonStaticServiceInstance.Configure(metricsConfig);
-                var receivedData = ReceiveData(
-                    nonStaticServiceInstance,
-                    "127.0.0.1",
-                    8125,
-                    () => { nonStaticServiceInstance.Increment("test"); });
-
-                Assert.AreEqual(new List<string> { "test:1|c\n" }, receivedData);
-            }
-        }
-
-        [Test]
         public void Setting_port()
         {
             using (var nonStaticServiceInstance = new DogStatsdService())
@@ -39,14 +18,14 @@ namespace Tests
                 var metricsConfig = new StatsdConfig
                 {
                     StatsdServerName = "127.0.0.1",
-                    StatsdPort = 8126,
+                    StatsdPort = 8127,
                 };
 
                 nonStaticServiceInstance.Configure(metricsConfig);
                 var receivedData = ReceiveData(
                     nonStaticServiceInstance,
                     "127.0.0.1",
-                    8126,
+                    8127,
                     () => { nonStaticServiceInstance.Increment("test"); });
 
                 Assert.AreEqual(new List<string> { "test:1|c\n" }, receivedData);
@@ -61,13 +40,13 @@ namespace Tests
                 var metricsConfig = new StatsdConfig
                 {
                     StatsdServerName = "127.0.0.1",
-                    StatsdPort = 8126,
+                    StatsdPort = 9128,
                 };
                 nonStaticServiceInstance.Configure(metricsConfig);
                 var receivedData = ReceiveData(
                     nonStaticServiceInstance,
                     "127.0.0.1",
-                    8125,
+                    8128,
                     () => { nonStaticServiceInstance.Increment("test"); });
 
                 Assert.AreEqual(0, receivedData.Count);
@@ -206,6 +185,7 @@ namespace Tests
                 var metricsConfig = new StatsdConfig
                 {
                     StatsdServerName = "127.0.0.1",
+                    StatsdPort = 8133,
                     StatsdMaxUDPPacketSize = 10,
                 };
                 service.Configure(metricsConfig);
@@ -213,7 +193,7 @@ namespace Tests
                 var receivedData = ReceiveData(
                     service,
                     metricsConfig.StatsdServerName,
-                    8125,
+                    8133,
                     () =>
                 {
                     service.Increment("test");

--- a/tests/StatsdClient.Tests/StatsdClient.Tests.csproj
+++ b/tests/StatsdClient.Tests/StatsdClient.Tests.csproj
@@ -17,13 +17,13 @@
     <CodeAnalysisRuleSet>..\..\stylecop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <DefineConstants>OS_WINDOWS</DefineConstants>
   </PropertyGroup>
 
   <!-- See https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/numeric-format-parsing-handles-higher-precision -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net5.0' ">
-    <DefineConstants>$(DefineConstants);NEW_DOUBLE_FORMATTING</DefineConstants>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net48' OR '$(TargetFramework.TrimEnd(`0123456789.`))' == 'netcoreapp'">
+    <DefineConstants>$(DefineConstants);OLD_DOUBLE_FORMATTING</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/StatsdClient.Tests/StatsdConfigurationTests.cs
+++ b/tests/StatsdClient.Tests/StatsdConfigurationTests.cs
@@ -30,20 +30,6 @@ namespace Tests
         }
 
         [Test]
-        public void Default_port_is_8125()
-        {
-            using (var sut = CreateSut())
-            {
-                var metricsConfig = new StatsdConfig
-                {
-                    StatsdServerName = "127.0.0.1",
-                };
-                Assert.True(sut.Configure(metricsConfig));
-                TestReceive("127.0.0.1", 8125, "test", "test:1|c\n", sut);
-            }
-        }
-
-        [Test]
         public void Setting_port()
         {
             using (var sut = CreateSut())
@@ -51,10 +37,10 @@ namespace Tests
                 var metricsConfig = new StatsdConfig
                 {
                     StatsdServerName = "127.0.0.1",
-                    StatsdPort = 8126,
+                    StatsdPort = 9126,
                 };
                 sut.Configure(metricsConfig);
-                TestReceive("127.0.0.1", 8126, "test", "test:1|c\n", sut);
+                TestReceive("127.0.0.1", 9126, "test", "test:1|c\n", sut);
             }
         }
 


### PR DESCRIPTION
## Context

This PR fixes a number of broken tests and adds a few small changes. In no particular order:

- we've changed `NEW_DOUBLE_FORMATTING` to `OLD_DOUBLE_FORMATTING` because the logic is more straightforward if we focus on changing the behavior for older versions with the old behavior (this fixes the `Gauge_double_rounding` test on versions newer than .NET 6.0)
- removed `Default_port_is_8125` test as it clashes with locally running Agent (we don't need this because we already know the default port is `8125` based on existing tests that assert the port field in the config defaults to `8125`)
- fixed `Setting_port`, `Setting_port_listen_on_other_port_should_return_no_data`, and `Test_message_too_long` ensuring they each listened on a unique port