### PR TITLE
[AGTMETRICS-347]Add tag cardinality option

### DIFF
--- a/src/StatsdClient/Aggregator/AggregatorFlusher.cs
+++ b/src/StatsdClient/Aggregator/AggregatorFlusher.cs
@@ -81,7 +81,7 @@ namespace StatsdClient.Aggregator
                 throw new ArgumentException($"Metric type is {metric.MetricType} instead of {_expectedMetricType}.");
             }
 
-            return new MetricStatsKey(metric.StatName, metric.Tags);
+            return new MetricStatsKey(metric.StatName, metric.Tags, metric.Cardinality);
         }
     }
 }

--- a/src/StatsdClient/Aggregator/MetricStatsKey.cs
+++ b/src/StatsdClient/Aggregator/MetricStatsKey.cs
@@ -38,6 +38,7 @@ namespace StatsdClient.Aggregator
                     hashCode = (hashCode * -1521134295) + tag.GetHashCode();
                 }
             }
+
             hashCode = (hashCode * -1521134295) + _cardinality.GetHashCode();
 
             return hashCode;

--- a/src/StatsdClient/Aggregator/MetricStatsKey.cs
+++ b/src/StatsdClient/Aggregator/MetricStatsKey.cs
@@ -10,18 +10,21 @@ namespace StatsdClient.Aggregator
     {
         private readonly string _metricName;
         private readonly string[] _tags;
+        private readonly Cardinality? _cardinality;
 
-        public MetricStatsKey(string metricName, string[] tags)
+        public MetricStatsKey(string metricName, string[] tags, Cardinality? cardinality = null)
         {
             _metricName = metricName;
             _tags = tags;
+            _cardinality = cardinality;
         }
 
         public override bool Equals(object obj)
         {
             return obj is MetricStatsKey key
                 && _metricName == key._metricName
-                && AreEquals(_tags, key._tags);
+                && AreEquals(_tags, key._tags)
+                && _cardinality == key._cardinality;
         }
 
         public override int GetHashCode()
@@ -35,6 +38,7 @@ namespace StatsdClient.Aggregator
                     hashCode = (hashCode * -1521134295) + tag.GetHashCode();
                 }
             }
+            hashCode = (hashCode * -1521134295) + _cardinality.GetHashCode();
 
             return hashCode;
         }

--- a/src/StatsdClient/DogStatsdService.cs
+++ b/src/StatsdClient/DogStatsdService.cs
@@ -80,11 +80,11 @@ namespace StatsdClient
         /// <param name="dateHappened">The epoch timestamp for the event (defaults to the current time from the DogStatsD server).</param>
         /// <param name="priority">Specifies the priority of the event (normal or low).</param>
         /// <param name="hostname">The name of the host.</param>
-        /// <param name="cardinality">The cardinality for tags added to this event.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        public void Event(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, Cardinality? cardinality = null, string[] tags = null)
+        /// <param name="cardinality">The cardinality for tags added to this event.</param>
+        public void Event(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, string[] tags = null, Cardinality? cardinality = null)
         {
-            _metricsSender?.SendEvent(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, cardinality, tags);
+            _metricsSender?.SendEvent(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, tags, cardinality);
         }
 
         /// <summary>

--- a/src/StatsdClient/DogStatsdService.cs
+++ b/src/StatsdClient/DogStatsdService.cs
@@ -80,10 +80,11 @@ namespace StatsdClient
         /// <param name="dateHappened">The epoch timestamp for the event (defaults to the current time from the DogStatsD server).</param>
         /// <param name="priority">Specifies the priority of the event (normal or low).</param>
         /// <param name="hostname">The name of the host.</param>
+        /// <param name="cardinality">The cardinality for tags added to this event.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        public void Event(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, string[] tags = null)
+        public void Event(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, Cardinality? cardinality = null, string[] tags = null)
         {
-            _metricsSender?.SendEvent(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, tags);
+            _metricsSender?.SendEvent(title, text, alertType, aggregationKey, sourceType, dateHappened, priority, hostname, cardinality, tags);
         }
 
         /// <summary>
@@ -94,9 +95,10 @@ namespace StatsdClient
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
         /// <param name="timestamp">BETA - Please contact our support team for more information to use this feature: https://www.datadoghq.com/support/ - Timestamp at which the counter has been seen with the given value. This value is sent without any aggregation.</param>
-        public void Counter(string statName, double value, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null)
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        public void Counter(string statName, double value, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null, Cardinality? cardinality = null)
         {
-            _metricsSender?.SendMetric(MetricType.Count, statName, value, sampleRate, tags, timestamp);
+            _metricsSender?.SendMetric(MetricType.Count, statName, value, sampleRate, tags, timestamp, cardinality);
         }
 
         /// <summary>
@@ -107,9 +109,10 @@ namespace StatsdClient
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
         /// <param name="timestamp">BETA - Please contact our support team for more information to use this feature: https://www.datadoghq.com/support/ - Timestamp at which the counter has been seen with the given value. This value is sent without any aggregation.</param>
-        public void Increment(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null)
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        public void Increment(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null, Cardinality? cardinality = null)
         {
-            _metricsSender?.SendMetric(MetricType.Count, statName, value, sampleRate, tags, timestamp);
+            _metricsSender?.SendMetric(MetricType.Count, statName, value, sampleRate, tags, timestamp, cardinality);
         }
 
         /// <summary>
@@ -120,9 +123,10 @@ namespace StatsdClient
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
         /// <param name="timestamp">BETA - Please contact our support team for more information to use this feature: https://www.datadoghq.com/support/ - Timestamp at which the counter has been seen with the given value. This value is sent without any aggregation.</param>
-        public void Decrement(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null)
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        public void Decrement(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null, Cardinality? cardinality = null)
         {
-            _metricsSender?.SendMetric(MetricType.Count, statName, -value, sampleRate, tags, timestamp);
+            _metricsSender?.SendMetric(MetricType.Count, statName, -value, sampleRate, tags, timestamp, cardinality);
         }
 
         /// <summary>
@@ -133,9 +137,10 @@ namespace StatsdClient
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
         /// <param name="timestamp">BETA - Please contact our support team for more information to use this feature: https://www.datadoghq.com/support/ - Timestamp at which the gauge has been seen with the given value. This value is sent without any aggregation.</param>
-        public void Gauge(string statName, double value, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null)
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        public void Gauge(string statName, double value, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null, Cardinality? cardinality = null)
         {
-            _metricsSender?.SendMetric(MetricType.Gauge, statName, value, sampleRate, tags, timestamp);
+            _metricsSender?.SendMetric(MetricType.Gauge, statName, value, sampleRate, tags, timestamp, cardinality);
         }
 
         /// <summary>
@@ -145,9 +150,10 @@ namespace StatsdClient
         /// <param name="value">The value of the histogram.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        public void Histogram(string statName, double value, double sampleRate = 1.0, string[] tags = null)
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        public void Histogram(string statName, double value, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null)
         {
-            _metricsSender?.SendMetric(MetricType.Histogram, statName, value, sampleRate, tags, null);
+            _metricsSender?.SendMetric(MetricType.Histogram, statName, value, sampleRate, tags, null, cardinality);
         }
 
         /// <summary>
@@ -157,9 +163,10 @@ namespace StatsdClient
         /// <param name="value">The value of the distribution.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        public void Distribution(string statName, double value, double sampleRate = 1.0, string[] tags = null)
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        public void Distribution(string statName, double value, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null)
         {
-            _metricsSender?.SendMetric(MetricType.Distribution, statName, value, sampleRate, tags, null);
+            _metricsSender?.SendMetric(MetricType.Distribution, statName, value, sampleRate, tags, null, cardinality);
         }
 
         /// <summary>
@@ -169,11 +176,12 @@ namespace StatsdClient
         /// <param name="value">The value to set.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
         /// <typeparam name="T">The type of the value.</typeparam>
-        public void Set<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null)
+        public void Set<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null)
         {
             var strValue = string.Format(CultureInfo.InvariantCulture, "{0}", value);
-            _metricsSender?.SendSetMetric(statName, strValue, sampleRate, tags);
+            _metricsSender?.SendSetMetric(statName, strValue, sampleRate, tags, cardinality);
         }
 
         /// <summary>
@@ -183,9 +191,10 @@ namespace StatsdClient
         /// <param name="value">The value to set.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        public void Set(string statName, string value, double sampleRate = 1.0, string[] tags = null)
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        public void Set(string statName, string value, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null)
         {
-            _metricsSender?.SendSetMetric(statName, value, sampleRate, tags);
+            _metricsSender?.SendSetMetric(statName, value, sampleRate, tags, cardinality);
         }
 
         /// <summary>
@@ -195,9 +204,10 @@ namespace StatsdClient
         /// <param name="value">The time in millisecond.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        public void Timer(string statName, double value, double sampleRate = 1.0, string[] tags = null)
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        public void Timer(string statName, double value, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null)
         {
-            _metricsSender?.SendMetric(MetricType.Timing, statName, value, sampleRate, tags, null);
+            _metricsSender?.SendMetric(MetricType.Timing, statName, value, sampleRate, tags, null, cardinality);
         }
 
         /// <summary>
@@ -206,10 +216,11 @@ namespace StatsdClient
         /// <param name="name">The name of the metric.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
         /// <returns>A disposable object that records the execution time until Dispose is called.</returns>
-        public IDisposable StartTimer(string name, double sampleRate = 1.0, string[] tags = null)
+        public IDisposable StartTimer(string name, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null)
         {
-            return new MetricsTimer(this, name, sampleRate, tags);
+            return new MetricsTimer(this, name, sampleRate, tags, cardinality);
         }
 
         /// <summary>
@@ -219,7 +230,8 @@ namespace StatsdClient
         /// <param name="statName">The name of the metric.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        public void Time(Action action, string statName, double sampleRate = 1.0, string[] tags = null)
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        public void Time(Action action, string statName, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null)
         {
             if (_metricsSender == null)
             {
@@ -227,7 +239,7 @@ namespace StatsdClient
             }
             else
             {
-                _metricsSender.Send(action, statName, sampleRate, tags);
+                _metricsSender.Send(action, statName, sampleRate, tags, cardinality);
             }
         }
 
@@ -238,16 +250,17 @@ namespace StatsdClient
         /// <param name="statName">The name of the metric.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
         /// <typeparam name="T">The type of the returned value of <paramref name="func"/>.</typeparam>
         /// <returns>The returned value of <paramref name="func"/>.</returns>
-        public T Time<T>(Func<T> func, string statName, double sampleRate = 1.0, string[] tags = null)
+        public T Time<T>(Func<T> func, string statName, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null)
         {
             if (_metricsSender == null)
             {
                 return func();
             }
 
-            using (StartTimer(statName, sampleRate, tags))
+            using (StartTimer(statName, sampleRate, tags, cardinality))
             {
                 return func();
             }
@@ -262,9 +275,10 @@ namespace StatsdClient
         /// <param name="hostname">The hostname to associate with the service check.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
         /// <param name="message">Additional information or a description of why the status occurred.</param>
-        public void ServiceCheck(string name, Status status, int? timestamp = null, string hostname = null, string[] tags = null, string message = null)
+        /// <param name="cardinality">The cardinality for tags added to this service check.</param>
+        public void ServiceCheck(string name, Status status, int? timestamp = null, string hostname = null, string[] tags = null, string message = null, Cardinality? cardinality = null)
         {
-            _metricsSender?.SendServiceCheck(name, (int)status, timestamp, hostname, tags, message);
+            _metricsSender?.SendServiceCheck(name, (int)status, timestamp, hostname, tags, message, cardinality);
         }
 
         /// <summary>

--- a/src/StatsdClient/Dogstatsd.cs
+++ b/src/StatsdClient/Dogstatsd.cs
@@ -38,10 +38,25 @@ namespace StatsdClient
     /// </summary>
     public enum Cardinality
     {
-	None,
-	Low,
-	Orchestrator,
-	High
+        /// <summary>
+        /// Cardinality None
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Cardinality Low
+        /// </summary>
+        Low,
+
+        /// <summary>
+        /// Cardinality Orchestrator
+        /// </summary>
+        Orchestrator,
+
+        /// <summary>
+        /// Cardinality High
+        /// </summary>
+        High,
     }
 
     /// <summary>
@@ -81,8 +96,8 @@ namespace StatsdClient
         /// <param name="dateHappened">The epoch timestamp for the event (defaults to the current time from the DogStatsD server).</param>
         /// <param name="priority">Specifies the priority of the event (normal or low).</param>
         /// <param name="hostname">The name of the host.</param>
-        /// <param name="cardinality">The cardinality for tags added to this event.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
+        /// <param name="cardinality">The cardinality for tags added to this event.</param>
         public static void Event(
             string title,
             string text,
@@ -93,7 +108,7 @@ namespace StatsdClient
             string priority = null,
             string hostname = null,
             string[] tags = null,
-	    Cardinality? cardinality = null)
+            Cardinality? cardinality = null)
             =>
                 _dogStatsdService.Event(
                     title: title,
@@ -104,7 +119,7 @@ namespace StatsdClient
                     dateHappened: dateHappened,
                     priority: priority,
                     hostname: hostname,
-		    cardinality: cardinality,
+                    cardinality: cardinality,
                     tags: tags);
 
         /// <summary>
@@ -229,6 +244,7 @@ namespace StatsdClient
         /// <param name="statName">The name of the metric.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
         public static void Time(Action action, string statName, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null) =>
             _dogStatsdService.Time(action: action, statName: statName, sampleRate: sampleRate, tags: tags, cardinality: cardinality);
 
@@ -239,6 +255,7 @@ namespace StatsdClient
         /// <param name="statName">The name of the metric.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
         /// <typeparam name="T">The type of the returned value of <paramref name="func"/>.</typeparam>
         /// <returns>The returned value of <paramref name="func"/>.</returns>
         public static T Time<T>(Func<T> func, string statName, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null) =>

--- a/src/StatsdClient/Dogstatsd.cs
+++ b/src/StatsdClient/Dogstatsd.cs
@@ -34,6 +34,17 @@ namespace StatsdClient
     }
 
     /// <summary>
+    /// The available options for Tag Cardinality.
+    /// </summary>
+    public enum Cardinality
+    {
+	None,
+	Low,
+	Orchestrator,
+	High
+    }
+
+    /// <summary>
     /// DogStatsd is a collection of static methods that provide the same feature as DogStatsdService.
     /// </summary>
     public static class DogStatsd
@@ -70,6 +81,7 @@ namespace StatsdClient
         /// <param name="dateHappened">The epoch timestamp for the event (defaults to the current time from the DogStatsD server).</param>
         /// <param name="priority">Specifies the priority of the event (normal or low).</param>
         /// <param name="hostname">The name of the host.</param>
+        /// <param name="cardinality">The cardinality for tags added to this event.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
         public static void Event(
             string title,
@@ -80,7 +92,8 @@ namespace StatsdClient
             int? dateHappened = null,
             string priority = null,
             string hostname = null,
-            string[] tags = null)
+            string[] tags = null,
+	    Cardinality? cardinality = null)
             =>
                 _dogStatsdService.Event(
                     title: title,
@@ -91,6 +104,7 @@ namespace StatsdClient
                     dateHappened: dateHappened,
                     priority: priority,
                     hostname: hostname,
+		    cardinality: cardinality,
                     tags: tags);
 
         /// <summary>
@@ -101,8 +115,9 @@ namespace StatsdClient
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
         /// <param name="timestamp">BETA - Please contact our support team for more information to use this feature: https://www.datadoghq.com/support/ - Timestamp at which the counter has been seen with the given value. This value is sent without any aggregation.</param>
-        public static void Counter(string statName, double value, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null) =>
-            _dogStatsdService.Counter(statName: statName, value: value, sampleRate: sampleRate, tags: tags, timestamp: timestamp);
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        public static void Counter(string statName, double value, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null, Cardinality? cardinality = null) =>
+            _dogStatsdService.Counter(statName: statName, value: value, sampleRate: sampleRate, tags: tags, timestamp: timestamp, cardinality: cardinality);
 
         /// <summary>
         /// Increments the specified counter.
@@ -112,8 +127,9 @@ namespace StatsdClient
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
         /// <param name="timestamp">BETA - Please contact our support team for more information to use this feature: https://www.datadoghq.com/support/ - Timestamp at which the counter has been seen with the given value. This value is sent without any aggregation.</param>
-        public static void Increment(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null) =>
-            _dogStatsdService.Increment(statName: statName, value: value, sampleRate: sampleRate, tags: tags, timestamp: timestamp);
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        public static void Increment(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null, Cardinality? cardinality = null) =>
+            _dogStatsdService.Increment(statName: statName, value: value, sampleRate: sampleRate, tags: tags, timestamp: timestamp, cardinality: cardinality);
 
         /// <summary>
         /// Decrements the specified counter.
@@ -123,8 +139,9 @@ namespace StatsdClient
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
         /// <param name="timestamp">BETA - Please contact our support team for more information to use this feature: https://www.datadoghq.com/support/ - Timestamp at which the counter has been seen with the given value. This value is sent without any aggregation.</param>
-        public static void Decrement(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null) =>
-            _dogStatsdService.Decrement(statName: statName, value: value, sampleRate: sampleRate, tags: tags, timestamp: timestamp);
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        public static void Decrement(string statName, int value = 1, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null, Cardinality? cardinality = null) =>
+            _dogStatsdService.Decrement(statName: statName, value: value, sampleRate: sampleRate, tags: tags, timestamp: timestamp, cardinality: cardinality);
 
         /// <summary>
         /// Records the latest fixed value for the specified named gauge.
@@ -134,8 +151,9 @@ namespace StatsdClient
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
         /// <param name="timestamp">BETA - Please contact our support team for more information to use this feature: https://www.datadoghq.com/support/ - Timestamp at which the gauge has been seen with the given value. This value is sent without any aggregation.</param>
-        public static void Gauge(string statName, double value, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null) =>
-            _dogStatsdService.Gauge(statName: statName, value: value, sampleRate: sampleRate, tags: tags, timestamp);
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        public static void Gauge(string statName, double value, double sampleRate = 1.0, string[] tags = null, DateTimeOffset? timestamp = null, Cardinality? cardinality = null) =>
+            _dogStatsdService.Gauge(statName: statName, value: value, sampleRate: sampleRate, tags: tags, timestamp, cardinality: cardinality);
 
         /// <summary>
         /// Records a value for the specified named histogram.
@@ -144,8 +162,9 @@ namespace StatsdClient
         /// <param name="value">The value of the histogram.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        public static void Histogram(string statName, double value, double sampleRate = 1.0, string[] tags = null) =>
-            _dogStatsdService.Histogram(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        public static void Histogram(string statName, double value, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null) =>
+            _dogStatsdService.Histogram(statName: statName, value: value, sampleRate: sampleRate, tags: tags, cardinality: cardinality);
 
         /// <summary>
         /// Records a value for the specified named distribution.
@@ -154,8 +173,9 @@ namespace StatsdClient
         /// <param name="value">The value of the distribution.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        public static void Distribution(string statName, double value, double sampleRate = 1.0, string[] tags = null) =>
-            _dogStatsdService.Distribution(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        public static void Distribution(string statName, double value, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null) =>
+            _dogStatsdService.Distribution(statName: statName, value: value, sampleRate: sampleRate, tags: tags, cardinality: cardinality);
 
         /// <summary>
         /// Records a value for the specified set.
@@ -164,9 +184,10 @@ namespace StatsdClient
         /// <param name="value">The value to set.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
         /// <typeparam name="T">The type of the value.</typeparam>
-        public static void Set<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null) =>
-            _dogStatsdService.Set<T>(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
+        public static void Set<T>(string statName, T value, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null) =>
+            _dogStatsdService.Set<T>(statName: statName, value: value, sampleRate: sampleRate, tags: tags, cardinality: cardinality);
 
         /// <summary>
         /// Records a value for the specified set.
@@ -175,8 +196,9 @@ namespace StatsdClient
         /// <param name="value">The value to set.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        public static void Set(string statName, string value, double sampleRate = 1.0, string[] tags = null) =>
-            _dogStatsdService.Set(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        public static void Set(string statName, string value, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null) =>
+            _dogStatsdService.Set(statName: statName, value: value, sampleRate: sampleRate, tags: tags, cardinality: cardinality);
 
         /// <summary>
         /// Records an execution time in milliseconds.
@@ -185,8 +207,9 @@ namespace StatsdClient
         /// <param name="value">The time in millisecond.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        public static void Timer(string statName, double value, double sampleRate = 1.0, string[] tags = null) =>
-            _dogStatsdService.Timer(statName: statName, value: value, sampleRate: sampleRate, tags: tags);
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        public static void Timer(string statName, double value, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null) =>
+            _dogStatsdService.Timer(statName: statName, value: value, sampleRate: sampleRate, tags: tags, cardinality: cardinality);
 
         /// <summary>
         /// Creates a timer that records the execution time until Dispose is called on the returned value.
@@ -194,9 +217,10 @@ namespace StatsdClient
         /// <param name="name">The name of the metric.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
         /// <returns>A disposable object that records the execution time until Dispose is called.</returns>
-        public static IDisposable StartTimer(string name, double sampleRate = 1.0, string[] tags = null) =>
-            _dogStatsdService.StartTimer(name: name, sampleRate: sampleRate, tags: tags);
+        public static IDisposable StartTimer(string name, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null) =>
+            _dogStatsdService.StartTimer(name: name, sampleRate: sampleRate, tags: tags, cardinality: cardinality);
 
         /// <summary>
         /// Records an execution time for the given action.
@@ -205,8 +229,8 @@ namespace StatsdClient
         /// <param name="statName">The name of the metric.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        public static void Time(Action action, string statName, double sampleRate = 1.0, string[] tags = null) =>
-            _dogStatsdService.Time(action: action, statName: statName, sampleRate: sampleRate, tags: tags);
+        public static void Time(Action action, string statName, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null) =>
+            _dogStatsdService.Time(action: action, statName: statName, sampleRate: sampleRate, tags: tags, cardinality: cardinality);
 
         /// <summary>
         /// Records an execution time for the given function.
@@ -217,8 +241,8 @@ namespace StatsdClient
         /// <param name="tags">Array of tags to be added to the data.</param>
         /// <typeparam name="T">The type of the returned value of <paramref name="func"/>.</typeparam>
         /// <returns>The returned value of <paramref name="func"/>.</returns>
-        public static T Time<T>(Func<T> func, string statName, double sampleRate = 1.0, string[] tags = null) =>
-            _dogStatsdService.Time<T>(func: func, statName: statName, sampleRate: sampleRate, tags: tags);
+        public static T Time<T>(Func<T> func, string statName, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null) =>
+            _dogStatsdService.Time<T>(func: func, statName: statName, sampleRate: sampleRate, tags: tags, cardinality: cardinality);
 
         /// <summary>
         /// Records a run status for the specified named service check.
@@ -229,14 +253,16 @@ namespace StatsdClient
         /// <param name="hostname">The hostname to associate with the service check.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
         /// <param name="message">Additional information or a description of why the status occurred.</param>
+        /// <param name="cardinality">The cardinality for tags added to this service check.</param>
         public static void ServiceCheck(
             string name,
             Status status,
             int? timestamp = null,
             string hostname = null,
             string[] tags = null,
-            string message = null) =>
-                _dogStatsdService.ServiceCheck(name, status, timestamp, hostname, tags, message);
+            string message = null,
+            Cardinality? cardinality = null) =>
+                _dogStatsdService.ServiceCheck(name, status, timestamp, hostname, tags, message, cardinality);
 
         /// <summary>
         /// Flushes all metrics.

--- a/src/StatsdClient/IDogStatsd.cs
+++ b/src/StatsdClient/IDogStatsd.cs
@@ -57,8 +57,8 @@ namespace StatsdClient
         /// <param name="dateHappened">The epoch timestamp for the event (defaults to the current time from the DogStatsD server).</param>
         /// <param name="priority">Specifies the priority of the event (normal or low).</param>
         /// <param name="hostname">The name of the host.</param>
-        /// <param name="cardinality">The cardinality for tags added to this event.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
+        /// <param name="cardinality">The cardinality for tags added to this event.</param>
         void Event(
             string title,
             string text,
@@ -68,8 +68,8 @@ namespace StatsdClient
             int? dateHappened = null,
             string priority = null,
             string hostname = null,
-            Cardinality? cardinality = null,
-            string[] tags = null);
+            string[] tags = null,
+            Cardinality? cardinality = null);
 
         /// <summary>
         /// Records the latest fixed value for the specified named gauge.

--- a/src/StatsdClient/IDogStatsd.cs
+++ b/src/StatsdClient/IDogStatsd.cs
@@ -32,7 +32,8 @@ namespace StatsdClient
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
         /// <param name="timestamp">BETA - Please contact our support team for more information to use this feature: https://www.datadoghq.com/support/ - Timestamp at which the counter has been seen with the given value. This value is sent without any aggregation.</param>
-        void Counter(string statName, double value, double sampleRate = 1, string[] tags = null, DateTimeOffset? timestamp = null);
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        void Counter(string statName, double value, double sampleRate = 1, string[] tags = null, DateTimeOffset? timestamp = null, Cardinality? cardinality = null);
 
         /// <summary>
         /// Decrements the specified counter.
@@ -42,7 +43,8 @@ namespace StatsdClient
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
         /// <param name="timestamp">BETA - Please contact our support team for more information to use this feature: https://www.datadoghq.com/support/ - Timestamp at which the counter has been seen with the given value. This value is sent without any aggregation.</param>
-        void Decrement(string statName, int value = 1, double sampleRate = 1, string[] tags = null, DateTimeOffset? timestamp = null);
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        void Decrement(string statName, int value = 1, double sampleRate = 1, string[] tags = null, DateTimeOffset? timestamp = null, Cardinality? cardinality = null);
 
         /// <summary>
         /// Records an event.
@@ -55,6 +57,7 @@ namespace StatsdClient
         /// <param name="dateHappened">The epoch timestamp for the event (defaults to the current time from the DogStatsD server).</param>
         /// <param name="priority">Specifies the priority of the event (normal or low).</param>
         /// <param name="hostname">The name of the host.</param>
+        /// <param name="cardinality">The cardinality for tags added to this event.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
         void Event(
             string title,
@@ -65,6 +68,7 @@ namespace StatsdClient
             int? dateHappened = null,
             string priority = null,
             string hostname = null,
+            Cardinality? cardinality = null,
             string[] tags = null);
 
         /// <summary>
@@ -75,7 +79,8 @@ namespace StatsdClient
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
         /// <param name="timestamp">BETA - Please contact our support team for more information to use this feature: https://www.datadoghq.com/support/ - Timestamp at which the gauge has been seen with the given value. This value is sent without any aggregation.</param>
-        void Gauge(string statName, double value, double sampleRate = 1, string[] tags = null, DateTimeOffset? timestamp = null);
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        void Gauge(string statName, double value, double sampleRate = 1, string[] tags = null, DateTimeOffset? timestamp = null, Cardinality? cardinality = null);
 
         /// <summary>
         /// Records a value for the specified named histogram.
@@ -84,7 +89,8 @@ namespace StatsdClient
         /// <param name="value">The value of the histogram.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        void Histogram(string statName, double value, double sampleRate = 1, string[] tags = null);
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        void Histogram(string statName, double value, double sampleRate = 1, string[] tags = null, Cardinality? cardinality = null);
 
         /// <summary>
         /// Records a value for the specified named distribution.
@@ -93,7 +99,8 @@ namespace StatsdClient
         /// <param name="value">The value of the distribution.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        void Distribution(string statName, double value, double sampleRate = 1, string[] tags = null);
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        void Distribution(string statName, double value, double sampleRate = 1, string[] tags = null, Cardinality? cardinality = null);
 
         /// <summary>
         /// Increments the specified counter.
@@ -103,7 +110,8 @@ namespace StatsdClient
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
         /// <param name="timestamp">BETA - Please contact our support team for more information to use this feature: https://www.datadoghq.com/support/ - Timestamp at which the counter has been seen with the given value. This value is sent without any aggregation.</param>
-        void Increment(string statName, int value = 1, double sampleRate = 1, string[] tags = null, DateTimeOffset? timestamp = null);
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        void Increment(string statName, int value = 1, double sampleRate = 1, string[] tags = null, DateTimeOffset? timestamp = null, Cardinality? cardinality = null);
 
         /// <summary>
         /// Records a value for the specified set.
@@ -112,8 +120,9 @@ namespace StatsdClient
         /// <param name="value">The value to set.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
         /// <typeparam name="T">The type of the value.</typeparam>
-        void Set<T>(string statName, T value, double sampleRate = 1, string[] tags = null);
+        void Set<T>(string statName, T value, double sampleRate = 1, string[] tags = null, Cardinality? cardinality = null);
 
         /// <summary>
         /// Records a value for the specified set.
@@ -122,7 +131,8 @@ namespace StatsdClient
         /// <param name="value">The value to set.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        void Set(string statName, string value, double sampleRate = 1, string[] tags = null);
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        void Set(string statName, string value, double sampleRate = 1, string[] tags = null, Cardinality? cardinality = null);
 
         /// <summary>
         /// Creates a timer that records the execution time until Dispose is called on the returned value.
@@ -130,8 +140,9 @@ namespace StatsdClient
         /// <param name="name">The name of the metric.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
         /// <returns>A disposable object that records the execution time until Dispose is called.</returns>
-        IDisposable StartTimer(string name, double sampleRate = 1, string[] tags = null);
+        IDisposable StartTimer(string name, double sampleRate = 1, string[] tags = null, Cardinality? cardinality = null);
 
         /// <summary>
         /// Records an execution time for the given action.
@@ -140,7 +151,8 @@ namespace StatsdClient
         /// <param name="statName">The name of the metric.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        void Time(Action action, string statName, double sampleRate = 1, string[] tags = null);
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        void Time(Action action, string statName, double sampleRate = 1, string[] tags = null, Cardinality? cardinality = null);
 
         /// <summary>
         /// Records an execution time for the given function.
@@ -149,9 +161,10 @@ namespace StatsdClient
         /// <param name="statName">The name of the metric.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
         /// <typeparam name="T">The type of the returned value of <paramref name="func"/>.</typeparam>
         /// <returns>The returned value of <paramref name="func"/>.</returns>
-        T Time<T>(Func<T> func, string statName, double sampleRate = 1, string[] tags = null);
+        T Time<T>(Func<T> func, string statName, double sampleRate = 1, string[] tags = null, Cardinality? cardinality = null);
 
         /// <summary>
         /// Records an execution time in milliseconds.
@@ -160,7 +173,8 @@ namespace StatsdClient
         /// <param name="value">The time in millisecond.</param>
         /// <param name="sampleRate">Percentage of metric to be sent.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
-        void Timer(string statName, double value, double sampleRate = 1, string[] tags = null);
+        /// <param name="cardinality">The cardinality for tags added to this metric.</param>
+        void Timer(string statName, double value, double sampleRate = 1, string[] tags = null, Cardinality? cardinality = null);
 
         /// <summary>
         /// Records a run status for the specified named service check.
@@ -171,13 +185,15 @@ namespace StatsdClient
         /// <param name="hostname">The hostname to associate with the service check.</param>
         /// <param name="tags">Array of tags to be added to the data.</param>
         /// <param name="message">Additional information or a description of why the status occurred.</param>
+        /// <param name="cardinality">The cardinality for tags added to this service check.</param>
         void ServiceCheck(
             string name,
             Status status,
             int? timestamp = null,
             string hostname = null,
             string[] tags = null,
-            string message = null);
+            string message = null,
+            Cardinality? cardinality = null);
 
         /// <summary>
         /// Flushes all metrics.

--- a/src/StatsdClient/MetricsSender.cs
+++ b/src/StatsdClient/MetricsSender.cs
@@ -29,7 +29,7 @@ namespace StatsdClient
             _defaultCardinality = defaultCardinality;
         }
 
-        public void SendEvent(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, Cardinality? cardinality = null, string[] tags = null, bool truncateIfTooLong = false)
+        public void SendEvent(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null, int? dateHappened = null, string priority = null, string hostname = null, string[] tags = null, Cardinality? cardinality = null, bool truncateIfTooLong = false)
         {
             if (TryDequeueStats(out var stats))
             {

--- a/src/StatsdClient/MetricsTimer.cs
+++ b/src/StatsdClient/MetricsTimer.cs
@@ -9,20 +9,22 @@ namespace StatsdClient
         private readonly DogStatsdService _dogStatsd;
         private readonly Stopwatch _stopWatch;
         private readonly double _sampleRate;
+        private readonly Cardinality? _cardinality;
         private bool _disposed;
 
-        public MetricsTimer(string name, double sampleRate = 1.0, string[] tags = null)
-            : this(null, name, sampleRate, tags)
+        public MetricsTimer(string name, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null)
+            : this(null, name, sampleRate, tags, cardinality)
         {
         }
 
-        public MetricsTimer(DogStatsdService dogStatsd, string name, double sampleRate = 1.0, string[] tags = null)
+        public MetricsTimer(DogStatsdService dogStatsd, string name, double sampleRate = 1.0, string[] tags = null, Cardinality? cardinality = null)
         {
             _name = name;
             _dogStatsd = dogStatsd;
             _stopWatch = new Stopwatch();
             _stopWatch.Start();
             _sampleRate = sampleRate;
+            _cardinality = cardinality;
             Tags = new List<string>();
             if (tags != null)
             {
@@ -41,11 +43,11 @@ namespace StatsdClient
 
                 if (_dogStatsd == null)
                 {
-                    DogStatsd.Timer(_name, _stopWatch.ElapsedMilliseconds(), _sampleRate, Tags.ToArray());
+                    DogStatsd.Timer(_name, _stopWatch.ElapsedMilliseconds(), _sampleRate, Tags.ToArray(), _cardinality);
                 }
                 else
                 {
-                    _dogStatsd.Timer(_name, _stopWatch.ElapsedMilliseconds(), _sampleRate, Tags.ToArray());
+                    _dogStatsd.Timer(_name, _stopWatch.ElapsedMilliseconds(), _sampleRate, Tags.ToArray(), _cardinality);
                 }
             }
         }

--- a/src/StatsdClient/OriginDetection.cs
+++ b/src/StatsdClient/OriginDetection.cs
@@ -65,7 +65,8 @@ namespace StatsdClient
         /// Initializes a new instance of the <see cref="OriginDetection"/> class.
         /// externalData is hardcoded for use in tests.
         /// </summary>
-        internal OriginDetection(string externalData) : this(externalData, string.Empty)
+        internal OriginDetection(string externalData)
+             : this(externalData, string.Empty)
         {
         }
 

--- a/src/StatsdClient/Serializer/EventSerializer.cs
+++ b/src/StatsdClient/Serializer/EventSerializer.cs
@@ -46,6 +46,8 @@ namespace StatsdClient
             _serializerHelper.AppendContainerID(builder);
             _serializerHelper.AppendExternalData(builder);
 
+            SerializerHelper.AppendIfNotNull(builder, "|card:", statsEvent.Cardinality?.ToString().ToLowerInvariant());
+
             if (builder.Length > MaxSize)
             {
                 if (statsEvent.TruncateIfTooLong)

--- a/src/StatsdClient/Serializer/MetricSerializer.cs
+++ b/src/StatsdClient/Serializer/MetricSerializer.cs
@@ -62,6 +62,8 @@ namespace StatsdClient
 
             _serializerHelper.AppendContainerID(builder);
             _serializerHelper.AppendExternalData(builder);
+
+            SerializerHelper.AppendIfNotNull(builder, "|card:", metricStats.Cardinality?.ToString().ToLowerInvariant());
         }
 
         private void AppendDouble(StringBuilder builder, double v)

--- a/src/StatsdClient/Serializer/ServiceCheckSerializer.cs
+++ b/src/StatsdClient/Serializer/ServiceCheckSerializer.cs
@@ -40,6 +40,8 @@ namespace StatsdClient
             _serializerHelper.AppendContainerID(builder);
             _serializerHelper.AppendExternalData(builder);
 
+            SerializerHelper.AppendIfNotNull(builder, "|card:", sc.Cardinality?.ToString().ToLowerInvariant());
+
             // Note: this must always be appended to the result last.
             SerializerHelper.AppendIfNotNull(builder, "|m:", processedMessage);
 

--- a/src/StatsdClient/Statistic/StatsEvent.cs
+++ b/src/StatsdClient/Statistic/StatsEvent.cs
@@ -27,6 +27,8 @@ namespace StatsdClient.Statistic
 
         public string[] Tags { get; set; }
 
+        public Cardinality? Cardinality { get; set; }
+
         public override bool Equals(object obj)
         {
             throw new NotSupportedException("The default implementation has performance issues.");

--- a/src/StatsdClient/Statistic/StatsMetric.cs
+++ b/src/StatsdClient/Statistic/StatsMetric.cs
@@ -21,6 +21,8 @@ namespace StatsdClient.Statistic
 
         public string[] Tags { get; set; }
 
+        public Cardinality? Cardinality { get; set; }
+
         public override bool Equals(object obj)
         {
             throw new NotSupportedException("The default implementation has performance issues.");

--- a/src/StatsdClient/Statistic/StatsServiceCheck.cs
+++ b/src/StatsdClient/Statistic/StatsServiceCheck.cs
@@ -21,6 +21,8 @@ namespace StatsdClient.Statistic
 
         public string[] Tags { get; set; }
 
+        public Cardinality? Cardinality { get; set; }
+
         public override bool Equals(object obj)
         {
             throw new NotSupportedException("The default implementation has performance issues.");

--- a/src/StatsdClient/StatsdBuilder.cs
+++ b/src/StatsdClient/StatsdBuilder.cs
@@ -47,7 +47,8 @@ namespace StatsdClient
                  new RandomGenerator(),
                  new StopWatchFactory(),
                  telemetry,
-                 config.StatsdTruncateIfTooLong);
+                 config.StatsdTruncateIfTooLong,
+                 config.Cardinality);
             return new StatsdData(metricsSender, statsBufferize, transport, telemetry);
         }
 

--- a/src/StatsdClient/StatsdConfig.cs
+++ b/src/StatsdClient/StatsdConfig.cs
@@ -154,5 +154,11 @@ namespace StatsdClient
         /// Gets or sets a value indicating whether or not origin detection is enabled.
         /// </summary>
         public bool? OriginDetection { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default cardinality for tags added to events and metrics.
+        /// This value is used when no cardinality is explicitly specified.
+        /// </summary>
+        public Cardinality? Cardinality { get; set; }
     }
 }

--- a/tests/StatsdClient.Tests/Aggregator/CountAggregatorTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/CountAggregatorTests.cs
@@ -75,7 +75,7 @@ namespace StatsdClient.Tests.Aggregator
 
             aggregator.TryFlush(force: true);
 
-            var output = handler.Value.Split('\n', StringSplitOptions.RemoveEmptyEntries).OrderBy(s => s).ToArray();
+            var output = handler.Value.Split(new char[] { '\n' }, StringSplitOptions.RemoveEmptyEntries).OrderBy(s => s).ToArray();
 
             Assert.AreEqual(
                 new[]
@@ -100,7 +100,7 @@ namespace StatsdClient.Tests.Aggregator
 
             aggregator.TryFlush(force: true);
 
-            var output = handler.Value.Split('\n', StringSplitOptions.RemoveEmptyEntries).OrderBy(s => s).ToArray();
+            var output = handler.Value.Split(new char[] { '\n' }, StringSplitOptions.RemoveEmptyEntries).OrderBy(s => s).ToArray();
 
             Assert.AreEqual(
                 new[]

--- a/tests/StatsdClient.Tests/Aggregator/CountAggregatorTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/CountAggregatorTests.cs
@@ -60,18 +60,73 @@ namespace StatsdClient.Tests.Aggregator
             }
         }
 
-        private static void AddStatsMetric(CountAggregator aggregator, string statName, double value)
+        [Test]
+        public void AggregatesByCardinality()
+        {
+            var handler = new BufferBuilderHandlerMock();
+            var aggregator = new CountAggregator(MetricAggregatorParametersFactory.Create(handler.Object));
+
+            // Add metrics with same name/tags but different cardinalities
+            AddStatsMetric(aggregator, "requests", 1, Cardinality.Low);
+            AddStatsMetric(aggregator, "requests", 2, Cardinality.Low); // Should aggregate with above
+            AddStatsMetric(aggregator, "requests", 3, Cardinality.High); // Should NOT aggregate with above
+            AddStatsMetric(aggregator, "requests", 4, Cardinality.High); // Should aggregate with previous High
+            AddStatsMetric(aggregator, "requests", 5, null); // Should NOT aggregate with any above
+
+            aggregator.TryFlush(force: true);
+
+            var output = handler.Value;
+            // Should have 3 separate metrics: Low (1+2=3), High (3+4=7), null (5)
+            Assert.True(output.Contains("requests:3|c|card:low"), "Expected Low cardinality metric with value 3");
+            Assert.True(output.Contains("requests:7|c|card:high"), "Expected High cardinality metric with value 7");
+            Assert.True(output.Contains("requests:5|c") && !output.Contains("requests:5|c|card:"), "Expected null cardinality metric with value 5");
+        }
+
+        [Test]
+        public void AggregatesByCardinalityWithTags()
+        {
+            var handler = new BufferBuilderHandlerMock();
+            var aggregator = new CountAggregator(MetricAggregatorParametersFactory.Create(handler.Object));
+
+            // Add metrics with same name/cardinality but different tags
+            AddStatsMetric(aggregator, "requests", 1, Cardinality.Low, new[] { "env:prod" });
+            AddStatsMetric(aggregator, "requests", 2, Cardinality.Low, new[] { "env:prod" }); // Should aggregate
+            AddStatsMetric(aggregator, "requests", 3, Cardinality.Low, new[] { "env:staging" }); // Different tags - should NOT aggregate
+            AddStatsMetric(aggregator, "requests", 4, Cardinality.High, new[] { "env:prod" }); // Different cardinality - should NOT aggregate
+
+            aggregator.TryFlush(force: true);
+
+            var output = handler.Value;
+            // Should have 3 separate metrics based on different key combinations
+            Assert.True(
+                output.Contains("requests:3|c") && (output.Contains("#card:low") || output.Contains("env:prod")),
+                "Expected Low cardinality metric with env:prod tag and value 3");
+            Assert.True(
+                output.Contains("requests:3|c") && (output.Contains("#card:low") || output.Contains("env:staging")),
+                "Expected Low cardinality metric with env:staging tag and value 3");
+            Assert.True(
+                output.Contains("requests:4|c") && (output.Contains("#card:high") || output.Contains("env:prod")),
+                "Expected High cardinality metric with env:prod tag and value 4");
+        }
+
+        private static void AddStatsMetric(CountAggregator aggregator, string statName, double value, Cardinality? cardinality = null, string[] tags = null)
         {
             var statsMetric = new StatsMetric
             {
-                MetricType = MetricType.
-                Count,
+                MetricType = MetricType.Count,
                 StatName = statName,
                 NumericValue = value,
                 SampleRate = 1,
+                Cardinality = cardinality,
+                Tags = tags,
             };
 
             aggregator.OnNewValue(ref statsMetric);
+        }
+
+        private static void AddStatsMetric(CountAggregator aggregator, string statName, double value)
+        {
+            AddStatsMetric(aggregator, statName, value, null, null);
         }
     }
 }

--- a/tests/StatsdClient.Tests/Aggregator/GaugeAggregatorTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/GaugeAggregatorTests.cs
@@ -20,16 +20,72 @@ namespace StatsdClient.Tests.Aggregator
             Assert.AreEqual("s1:2|g|@0\ns2:3|g|@0\n", handler.Value);
         }
 
-        private static void AddStatsMetric(GaugeAggregator aggregator, string statName, double value)
+        [Test]
+        public void AggregatesByCardinality()
+        {
+            var handler = new BufferBuilderHandlerMock();
+            var aggregator = new GaugeAggregator(MetricAggregatorParametersFactory.Create(handler.Object));
+
+            // Add metrics with same name but different cardinalities
+            // Gauge aggregation keeps the last value per unique key
+            AddStatsMetric(aggregator, "cpu_usage", 10.0, Cardinality.Low);
+            AddStatsMetric(aggregator, "cpu_usage", 20.0, Cardinality.Low); // Should replace above (last value wins)
+            AddStatsMetric(aggregator, "cpu_usage", 30.0, Cardinality.High); // Different cardinality - should NOT replace above
+            AddStatsMetric(aggregator, "cpu_usage", 40.0, null); // Different cardinality (null) - should NOT replace above
+
+            aggregator.TryFlush(force: true);
+
+            var output = handler.Value;
+            // Should have 3 separate gauge metrics: Low=20.0, High=30.0, null=40.0
+            Assert.True(output.Contains("cpu_usage:20|g") && output.Contains("card:low"), "Expected Low cardinality gauge with value 20.0");
+            Assert.True(output.Contains("cpu_usage:30|g") && output.Contains("card:high"), "Expected High cardinality gauge with value 30.0");
+            Assert.True(output.Contains("cpu_usage:40|g") && !output.Contains("cpu_usage:40|g|card:"), "Expected null cardinality gauge with value 40.0");
+        }
+
+        [Test]
+        public void AggregatesByCardinalityWithTags()
+        {
+            var handler = new BufferBuilderHandlerMock();
+            var aggregator = new GaugeAggregator(MetricAggregatorParametersFactory.Create(handler.Object));
+
+            // Add metrics with different combinations of cardinality and tags
+            AddStatsMetric(aggregator, "memory", 100.0, Cardinality.Low, new[] { "host:server1" });
+            AddStatsMetric(aggregator, "memory", 200.0, Cardinality.Low, new[] { "host:server1" }); // Same key - should replace
+            AddStatsMetric(aggregator, "memory", 150.0, Cardinality.Low, new[] { "host:server2" }); // Different tag - different key
+            AddStatsMetric(aggregator, "memory", 300.0, Cardinality.High, new[] { "host:server1" }); // Different cardinality - different key
+
+            aggregator.TryFlush(force: true);
+
+            var output = handler.Value;
+            // Should have 3 separate gauge metrics
+            Assert.True(
+                output.Contains("memory:200|g") && (output.Contains("card:low") || output.Contains("host:server1")),
+                "Expected Low cardinality gauge with host:server1 and value 200.0");
+            Assert.True(
+                output.Contains("memory:150|g") && (output.Contains("card:low") || output.Contains("host:server2")),
+                "Expected Low cardinality gauge with host:server2 and value 150.0");
+            Assert.True(
+                output.Contains("memory:300|g") && (output.Contains("card:high") || output.Contains("host:server1")),
+                "Expected High cardinality gauge with host:server1 and value 300.0");
+        }
+
+        private static void AddStatsMetric(GaugeAggregator aggregator, string statName, double value, Cardinality? cardinality = null, string[] tags = null)
         {
             var statsMetric = new StatsMetric
             {
                 MetricType = MetricType.Gauge,
                 StatName = statName,
                 NumericValue = value,
+                Cardinality = cardinality,
+                Tags = tags,
             };
 
             aggregator.OnNewValue(ref statsMetric);
+        }
+
+        private static void AddStatsMetric(GaugeAggregator aggregator, string statName, double value)
+        {
+            AddStatsMetric(aggregator, statName, value, null, null);
         }
     }
 }

--- a/tests/StatsdClient.Tests/Aggregator/GaugeAggregatorTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/GaugeAggregatorTests.cs
@@ -37,7 +37,7 @@ namespace StatsdClient.Tests.Aggregator
 
             aggregator.TryFlush(force: true);
 
-            var output = handler.Value.Split('\n', StringSplitOptions.RemoveEmptyEntries).OrderBy(s => s).ToArray();
+            var output = handler.Value.Split(new char[] { '\n' }, StringSplitOptions.RemoveEmptyEntries).OrderBy(s => s).ToArray();
 
             Assert.AreEqual(
                 new[]
@@ -62,7 +62,7 @@ namespace StatsdClient.Tests.Aggregator
 
             aggregator.TryFlush(force: true);
 
-            var output = handler.Value.Split('\n', StringSplitOptions.RemoveEmptyEntries).OrderBy(s => s).ToArray();
+            var output = handler.Value.Split(new char[] { '\n' }, StringSplitOptions.RemoveEmptyEntries).OrderBy(s => s).ToArray();
 
             Assert.AreEqual(
                 new[]

--- a/tests/StatsdClient.Tests/Aggregator/MetricStatsKeyTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/MetricStatsKeyTests.cs
@@ -27,5 +27,30 @@ namespace StatsdClient.Tests.Aggregator
                 new MetricStatsKey("m1", new[] { "tag" }).GetHashCode(),
                 new MetricStatsKey("m1", new[] { "tag" }).GetHashCode());
         }
+
+        [Test]
+        public void EqualsWithCardinality()
+        {
+            Assert.AreEqual(
+                new MetricStatsKey("m1", new[] { "tag" }, Cardinality.Low),
+                new MetricStatsKey("m1", new[] { "tag" }, Cardinality.Low));
+            Assert.AreNotEqual(
+                new MetricStatsKey("m1", new[] { "tag" }, Cardinality.Low),
+                new MetricStatsKey("m1", new[] { "tag" }, Cardinality.High));
+            Assert.AreNotEqual(
+                new MetricStatsKey("m1", new[] { "tag" }, Cardinality.Low),
+                new MetricStatsKey("m1", new[] { "tag" }, null));
+        }
+
+        [Test]
+        public void HashCodeWithCardinality()
+        {
+            Assert.AreEqual(
+                new MetricStatsKey("m1", new[] { "tag" }, Cardinality.Low).GetHashCode(),
+                new MetricStatsKey("m1", new[] { "tag" }, Cardinality.Low).GetHashCode());
+            Assert.AreNotEqual(
+                new MetricStatsKey("m1", new[] { "tag" }, Cardinality.Low).GetHashCode(),
+                new MetricStatsKey("m1", new[] { "tag" }, Cardinality.High).GetHashCode());
+        }
     }
 }

--- a/tests/StatsdClient.Tests/Aggregator/SetAggregatorTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/SetAggregatorTests.cs
@@ -59,7 +59,7 @@ namespace StatsdClient.Tests.Aggregator
 
             aggregator.TryFlush(force: true);
 
-            var output = handler.Value.Split('\n', StringSplitOptions.RemoveEmptyEntries).OrderBy(s => s).ToArray();
+            var output = handler.Value.Split(new char[] { '\n' }, StringSplitOptions.RemoveEmptyEntries).OrderBy(s => s).ToArray();
 
             Assert.AreEqual(
                 new[]
@@ -84,7 +84,7 @@ namespace StatsdClient.Tests.Aggregator
             AddStatsMetric(aggregator, "session_ids", "session4", Cardinality.High, new[] { "region:us" }); // Different cardinality - different key
 
             aggregator.TryFlush(force: true);
-            var output = handler.Value.Split('\n', StringSplitOptions.RemoveEmptyEntries).OrderBy(s => s).ToArray();
+            var output = handler.Value.Split(new char[] { '\n' }, StringSplitOptions.RemoveEmptyEntries).OrderBy(s => s).ToArray();
 
             Assert.AreEqual(
                 new[]

--- a/tests/StatsdClient.Tests/Aggregator/SetAggregatorTests.cs
+++ b/tests/StatsdClient.Tests/Aggregator/SetAggregatorTests.cs
@@ -42,16 +42,116 @@ namespace StatsdClient.Tests.Aggregator
             }
         }
 
-        private static void AddStatsMetric(SetAggregator aggregator, string statName, string value)
+        [Test]
+        public void AggregatesByCardinality()
+        {
+            var handler = new BufferBuilderHandlerMock();
+            var aggregator = new SetAggregator(MetricAggregatorParametersFactory.Create(handler.Object), null, Tools.ExceptionHandler);
+
+            // Add metrics with same name but different cardinalities
+            // Set aggregation keeps unique values per unique key
+            AddStatsMetric(aggregator, "unique_users", "user1", Cardinality.Low);
+            AddStatsMetric(aggregator, "unique_users", "user2", Cardinality.Low); // Same cardinality - should be in same set
+            AddStatsMetric(aggregator, "unique_users", "user1", Cardinality.Low); // Duplicate value in same set - should dedupe
+            AddStatsMetric(aggregator, "unique_users", "user1", Cardinality.High); // Different cardinality - different set
+            AddStatsMetric(aggregator, "unique_users", "user3", null); // Different cardinality (null) - different set
+
+            aggregator.TryFlush(force: true);
+
+            var output = handler.Value;
+            // Should have separate sets for each cardinality
+            // Low cardinality: user1, user2 (2 unique values)
+            // High cardinality: user1 (1 unique value)
+            // Null cardinality: user3 (1 unique value)
+            var lowCardinalityLines = 0;
+            var highCardinalityLines = 0;
+            var nullCardinalityLines = 0;
+
+            foreach (var line in output.Split('\n'))
+            {
+                if (line.Contains("unique_users:") && line.Contains("|s"))
+                {
+                    if (line.Contains("card:low"))
+                    {
+                        lowCardinalityLines++;
+                    }
+                    else if (line.Contains("card:high"))
+                    {
+                        highCardinalityLines++;
+                    }
+                    else if (!line.Contains("card:"))
+                    {
+                        nullCardinalityLines++;
+                    }
+                }
+            }
+
+            Assert.AreEqual(2, lowCardinalityLines, "Expected 2 unique values in Low cardinality set");
+            Assert.AreEqual(1, highCardinalityLines, "Expected 1 unique value in High cardinality set");
+            Assert.AreEqual(1, nullCardinalityLines, "Expected 1 unique value in null cardinality set");
+        }
+
+        [Test]
+        public void AggregatesByCardinalityWithTags()
+        {
+            var handler = new BufferBuilderHandlerMock();
+            var aggregator = new SetAggregator(MetricAggregatorParametersFactory.Create(handler.Object), null, Tools.ExceptionHandler);
+
+            // Add metrics with different combinations of cardinality and tags
+            AddStatsMetric(aggregator, "session_ids", "session1", Cardinality.Low, new[] { "region:us" });
+            AddStatsMetric(aggregator, "session_ids", "session2", Cardinality.Low, new[] { "region:us" }); // Same key - same set
+            AddStatsMetric(aggregator, "session_ids", "session3", Cardinality.Low, new[] { "region:eu" }); // Different tag - different key
+            AddStatsMetric(aggregator, "session_ids", "session4", Cardinality.High, new[] { "region:us" }); // Different cardinality - different key
+
+            aggregator.TryFlush(force: true);
+
+            var output = handler.Value;
+
+            var usLowCount = 0;
+            var euLowCount = 0;
+            var usHighCount = 0;
+
+            foreach (var line in output.Split('\n'))
+            {
+                if (line.Contains("session_ids:") && line.Contains("|s"))
+                {
+                    if (line.Contains("card:low") && line.Contains("region:us"))
+                    {
+                        usLowCount++;
+                    }
+                    else if (line.Contains("card:low") && line.Contains("region:eu"))
+                    {
+                        euLowCount++;
+                    }
+                    else if (line.Contains("card:high") && line.Contains("region:us"))
+                    {
+                        usHighCount++;
+                    }
+                }
+            }
+
+            Assert.AreEqual(2, usLowCount, "Expected 2 unique values in Low cardinality, US region set");
+            Assert.AreEqual(1, euLowCount, "Expected 1 unique value in Low cardinality, EU region set");
+            Assert.AreEqual(1, usHighCount, "Expected 1 unique value in High cardinality, US region set");
+        }
+
+        private static void AddStatsMetric(SetAggregator aggregator, string statName, string value, Cardinality? cardinality = null, string[] tags = null)
         {
             var statsMetric = new StatsMetric
             {
                 MetricType = MetricType.Set,
                 StatName = statName,
                 StringValue = value,
+                Cardinality = cardinality,
+                Tags = tags,
             };
 
             aggregator.OnNewValue(ref statsMetric);
+        }
+
+        private static void AddStatsMetric(SetAggregator aggregator, string statName, string value)
+        {
+            AddStatsMetric(aggregator, statName, value, null, null);
         }
     }
 }

--- a/tests/StatsdClient.Tests/Serializer/EventSerializerTests.cs
+++ b/tests/StatsdClient.Tests/Serializer/EventSerializerTests.cs
@@ -128,6 +128,53 @@ namespace StatsdClient.Tests
                 truncateIfTooLong: true);
         }
 
+        [Test]
+        public void SendEventWithCardinalityLow()
+        {
+            AssertSerialize("_e{5,4}:title|text|card:low", "title", "text", cardinality: Cardinality.Low);
+        }
+
+        [Test]
+        public void SendEventWithCardinalityHigh()
+        {
+            AssertSerialize("_e{5,4}:title|text|card:high", "title", "text", cardinality: Cardinality.High);
+        }
+
+        [Test]
+        public void SendEventWithCardinalityOrchestrator()
+        {
+            AssertSerialize("_e{5,4}:title|text|card:orchestrator", "title", "text", cardinality: Cardinality.Orchestrator);
+        }
+
+        [Test]
+        public void SendEventWithCardinalityNone()
+        {
+            AssertSerialize("_e{5,4}:title|text|card:none", "title", "text", cardinality: Cardinality.None);
+        }
+
+        [Test]
+        public void SendEventWithCardinalityAndTags()
+        {
+            AssertSerialize("_e{5,4}:title|text|#tag1,tag2|card:low", "title", "text", cardinality: Cardinality.Low, tags: new[] { "tag1", "tag2" });
+        }
+
+        [Test]
+        public void SendEventWithCardinalityAndMultipleFields()
+        {
+            AssertSerialize(
+                "_e{5,4}:title|text|d:123456|h:hostname|k:key|p:low|s:source|t:warning|#tag1,tag2|card:high",
+                "title",
+                "text",
+                alertType: "warning",
+                aggregationKey: "key",
+                sourceType: "source",
+                dateHappened: 123456,
+                priority: "low",
+                hostname: "hostname",
+                cardinality: Cardinality.High,
+                tags: new[] { "tag1", "tag2" });
+        }
+
         private static string BuildLongString(int length)
         {
             var builder = new StringBuilder();
@@ -152,7 +199,8 @@ namespace StatsdClient.Tests
             string[] tags = null,
             bool truncateIfTooLong = false,
             string externalData = null,
-            string containerID = null)
+            string containerID = null,
+            Cardinality? cardinality = null)
         {
             var serializer = CreateSerializer(externalData, containerID);
             var statsEvent = new StatsEvent
@@ -167,6 +215,7 @@ namespace StatsdClient.Tests
                 Hostname = hostname,
                 TruncateIfTooLong = truncateIfTooLong,
                 Tags = tags,
+                Cardinality = cardinality,
             };
 
             var serializedMetric = new SerializedMetric();

--- a/tests/StatsdClient.Tests/Serializer/MetricSerializerTests.cs
+++ b/tests/StatsdClient.Tests/Serializer/MetricSerializerTests.cs
@@ -476,6 +476,139 @@ namespace StatsdClient.Tests
                 externalData: "set-external-data");
         }
 
+        [Test]
+        public void SendCounterWithCardinalityLow()
+        {
+            AssertSerialize("counter:5|c|card:low", MetricType.Count, "counter", 5, cardinality: Cardinality.Low);
+        }
+
+        [Test]
+        public void SendCounterWithCardinalityHigh()
+        {
+            AssertSerialize("counter:5|c|card:high", MetricType.Count, "counter", 5, cardinality: Cardinality.High);
+        }
+
+        [Test]
+        public void SendCounterWithCardinalityOrchestrator()
+        {
+            AssertSerialize("counter:5|c|card:orchestrator", MetricType.Count, "counter", 5, cardinality: Cardinality.Orchestrator);
+        }
+
+        [Test]
+        public void SendCounterWithCardinalityNone()
+        {
+            AssertSerialize("counter:5|c|card:none", MetricType.Count, "counter", 5, cardinality: Cardinality.None);
+        }
+
+        [Test]
+        public void SendCounterWithCardinalityAndTags()
+        {
+            AssertSerialize(
+                "counter:5|c|#tag1:true,tag2|card:low",
+                MetricType.Count,
+                "counter",
+                5,
+                tags: new[] { "tag1:true", "tag2" },
+                cardinality: Cardinality.Low);
+        }
+
+        [Test]
+        public void SendCounterWithCardinalityAndSampleRate()
+        {
+            AssertSerialize(
+                "counter:5|c|@0.1|card:high",
+                MetricType.Count,
+                "counter",
+                5,
+                sampleRate: 0.1,
+                cardinality: Cardinality.High);
+        }
+
+        [Test]
+        public void SendCounterWithCardinalityTagsAndSampleRate()
+        {
+            AssertSerialize(
+                "counter:5|c|@0.1|#tag1:true,tag2|card:orchestrator",
+                MetricType.Count,
+                "counter",
+                5,
+                sampleRate: 0.1,
+                tags: new[] { "tag1:true", "tag2" },
+                cardinality: Cardinality.Orchestrator);
+        }
+
+        [Test]
+        public void SendCounterWithCardinalityAndTimestamp()
+        {
+            var dto = new DateTimeOffset(2013, 05, 01, 18, 30, 00, new TimeSpan(0, 0, 0));
+            AssertSerialize(
+                "counter:5|c|T1367433000|card:low",
+                MetricType.Count,
+                "counter",
+                5,
+                timestamp: dto,
+                cardinality: Cardinality.Low);
+        }
+
+        [Test]
+        public void SendGaugeWithCardinalityAndTimestamp()
+        {
+            var dto = new DateTimeOffset(2013, 05, 01, 18, 30, 00, new TimeSpan(0, 0, 0));
+            AssertSerialize(
+                "gauge:5|g|T1367433000|card:high",
+                MetricType.Gauge,
+                "gauge",
+                5,
+                timestamp: dto,
+                cardinality: Cardinality.High);
+        }
+
+        [Test]
+        public void SendHistogramWithCardinality()
+        {
+            AssertSerialize("histogram:5|h|card:low", MetricType.Histogram, "histogram", 5, cardinality: Cardinality.Low);
+        }
+
+        [Test]
+        public void SendDistributionWithCardinality()
+        {
+            AssertSerialize("distribution:5|d|card:high", MetricType.Distribution, "distribution", 5, cardinality: Cardinality.High);
+        }
+
+        [Test]
+        public void SendTimerWithCardinality()
+        {
+            AssertSerialize("timer:5|ms|card:orchestrator", MetricType.Timing, "timer", 5, cardinality: Cardinality.Orchestrator);
+        }
+
+        [Test]
+        public void SendSetWithCardinality()
+        {
+            AssertSetSerialize("set:value|s|card:low", "set", "value", cardinality: Cardinality.Low);
+        }
+
+        [Test]
+        public void SendSetWithCardinalityAndTags()
+        {
+            AssertSetSerialize(
+                "set:value|s|#tag1:true|card:high",
+                "set",
+                "value",
+                tags: new[] { "tag1:true" },
+                cardinality: Cardinality.High);
+        }
+
+        [Test]
+        public void SendSetWithCardinalityAndSampleRate()
+        {
+            AssertSetSerialize(
+                "set:value|s|@0.5|card:none",
+                "set",
+                "value",
+                sampleRate: 0.5,
+                cardinality: Cardinality.None);
+        }
+
         private static void AssertSerialize(
             string expectValue,
             MetricType metricType,
@@ -486,7 +619,8 @@ namespace StatsdClient.Tests
             string prefix = null,
             DateTimeOffset? timestamp = null,
             string externalData = null,
-            string containerID = null)
+            string containerID = null,
+            Cardinality? cardinality = null)
         {
             var statsMetric = new StatsMetric
             {
@@ -495,6 +629,7 @@ namespace StatsdClient.Tests
                 SampleRate = sampleRate,
                 NumericValue = value,
                 Tags = tags,
+                Cardinality = cardinality,
             };
             if (timestamp != null)
             {
@@ -512,7 +647,8 @@ namespace StatsdClient.Tests
            string[] tags = null,
            string prefix = null,
            string externalData = null,
-           string containerID = null)
+           string containerID = null,
+           Cardinality? cardinality = null)
         {
             var statsMetric = new StatsMetric
             {
@@ -521,6 +657,7 @@ namespace StatsdClient.Tests
                 SampleRate = sampleRate,
                 StringValue = value.ToString(),
                 Tags = tags,
+                Cardinality = cardinality,
             };
             AssertSerialize(expectValue, ref statsMetric, prefix, externalData, containerID);
         }
@@ -530,7 +667,7 @@ namespace StatsdClient.Tests
            ref StatsMetric statsMetric,
            string prefix,
            string externalData,
-       string containerID)
+           string containerID)
         {
             var originDetection = new OriginDetection(externalData, containerID);
             var serializerHelper = new SerializerHelper(null, originDetection);

--- a/tests/StatsdClient.Tests/Serializer/ServiceCheckSerializerTests.cs
+++ b/tests/StatsdClient.Tests/Serializer/ServiceCheckSerializerTests.cs
@@ -120,6 +120,50 @@ namespace StatsdClient.Tests
             Assert.That(exception.Message, Contains.Substring("payload is too big"));
         }
 
+        [Test]
+        public void SendServiceCheckWithCardinalityLow()
+        {
+            AssertSerialize("_sc|name|0|card:low", "name", 0, cardinality: Cardinality.Low);
+        }
+
+        [Test]
+        public void SendServiceCheckWithCardinalityHigh()
+        {
+            AssertSerialize("_sc|name|0|card:high", "name", 0, cardinality: Cardinality.High);
+        }
+
+        [Test]
+        public void SendServiceCheckWithCardinalityOrchestrator()
+        {
+            AssertSerialize("_sc|name|0|card:orchestrator", "name", 0, cardinality: Cardinality.Orchestrator);
+        }
+
+        [Test]
+        public void SendServiceCheckWithCardinalityNone()
+        {
+            AssertSerialize("_sc|name|0|card:none", "name", 0, cardinality: Cardinality.None);
+        }
+
+        [Test]
+        public void SendServiceCheckWithCardinalityAndTags()
+        {
+            AssertSerialize("_sc|name|0|#tag1,tag2|card:low", "name", 0, cardinality: Cardinality.Low, tags: new[] { "tag1", "tag2" });
+        }
+
+        [Test]
+        public void SendServiceCheckWithCardinalityAndAllOptional()
+        {
+            AssertSerialize(
+                "_sc|name|0|d:1|h:hostname|#tag1,tag2|card:high|m:message",
+                "name",
+                0,
+                timestamp: 1,
+                hostname: "hostname",
+                cardinality: Cardinality.High,
+                tags: new[] { "tag1", "tag2" },
+                serviceCheckMessage: "message");
+        }
+
         private static string BuildLongString(int length)
         {
             var builder = new StringBuilder();
@@ -141,9 +185,10 @@ namespace StatsdClient.Tests
             string serviceCheckMessage = null,
             bool truncateIfTooLong = false,
             string externalData = null,
-            string containerID = null)
+            string containerID = null,
+            Cardinality? cardinality = null)
         {
-            var serializedMetric = Serialize(name, status, timestamp, hostname, tags, serviceCheckMessage, truncateIfTooLong, externalData, containerID);
+            var serializedMetric = Serialize(name, status, timestamp, hostname, tags, serviceCheckMessage, truncateIfTooLong, externalData, containerID, cardinality);
             Assert.AreEqual(expectValue, serializedMetric.ToString());
         }
 
@@ -156,7 +201,8 @@ namespace StatsdClient.Tests
                     string serviceCheckMessage = null,
                     bool truncateIfTooLong = false,
                     string externalData = null,
-                    string containerID = null)
+                    string containerID = null,
+                    Cardinality? cardinality = null)
         {
             var statsServiceCheck = new StatsServiceCheck
             {
@@ -167,6 +213,7 @@ namespace StatsdClient.Tests
                 ServiceCheckMessage = serviceCheckMessage,
                 TruncateIfTooLong = truncateIfTooLong,
                 Tags = tags,
+                Cardinality = cardinality,
             };
             var serializer = CreateSerializer(externalData, containerID);
             var serializedMetric = new SerializedMetric();


### PR DESCRIPTION
This adds the tag cardinality option. A global setting can be applied via the config options. It can be overriden per metric if needed.