### PR TITLE
Add Claude skills to help release the package

### DIFF
--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: prepare-release
+description: "Prepare a DogStatsD C# client release PR. Creates a release branch, updates CHANGELOG.md, runs pimpmychangelog, bumps version in StatsdClient.csproj, commits, and opens a GitHub PR targeting master. Triggers on: prepare release, create release PR, start release, open release branch."
+user-invocable: true
+---
+
+# Prepare Release PR
+
+Create a release branch with version bump and changelog, then open a PR for review.
+
+---
+
+## Step 1: Confirm Version
+
+If the user did not supply a version number, read `src/StatsdClient/StatsdClient.csproj` and show the current `<PackageVersion>`. Ask: "Prepare release for X.Y.Z?" and wait for confirmation before proceeding.
+
+---
+
+## Step 2: Create Release Branch
+
+```bash
+git checkout master
+git pull origin master
+git checkout -b release/X.Y.Z
+```
+
+---
+
+## Step 3: Update CHANGELOG.md
+
+- Open `CHANGELOG.md`.
+- If a section for the target version already exists, leave it as-is.
+- If not, add a new section at the top (below the `CHANGELOG\n=========` header) in the same format as existing entries:
+
+```
+# X.Y.Z / YYYY-MM-DD
+
+## Changes
+
+* [FEATURE/IMPROVEMENT/BUGFIX] Description here. See [#NNN][].
+```
+
+Use today's date. Do **not** delete any existing entries.
+
+After writing, run `pimpmychangelog` from the repo root. It rewrites `CHANGELOG.md` in-place to add GitHub-style reference links at the bottom. Show the user the diff and ask if they want to adjust the changelog before continuing.
+
+---
+
+## Step 4: Update Version in StatsdClient.csproj
+
+Edit `src/StatsdClient/StatsdClient.csproj`:
+- Set `<PackageVersion>` to the release version.
+- Set `<Version>` to the major version, do not change the minor version (always `MAJOR.MINOR.PATCH`, no pre-release suffix).
+
+> <Version>: This is the assembly version. You must update this value only when there is a major version change. See Create strong named .NET libraries for explanations.
+> Example: When updating from version 4.0.0 to version 4.1.0, you must set <PackageVersion>4.1.0</PackageVersion> and <Version>4.0.0</Version> (and NOT <Version>4.1.0</Version>).
+
+Example — releasing `9.2.0`:
+```xml
+<PackageVersion>9.2.0</PackageVersion>
+<Version>9.0.0</Version>
+```
+
+---
+
+## Step 5: Commit and Push
+
+```bash
+git add CHANGELOG.md src/StatsdClient/StatsdClient.csproj
+git commit -m "Release version X.Y.Z"
+git push -u origin release/X.Y.Z
+```
+
+---
+
+## Step 6: Open Pull Request
+
+Create a PR targeting `master`:
+
+```bash
+gh pr create \
+  --base master \
+  --title "Release X.Y.Z" \
+  --body "$(cat <<'EOF'
+## Release X.Y.Z
+
+Changelog and version bump for the X.Y.Z NuGet release.
+
+### Checklist
+- [ ] Changelog entries are accurate
+- [ ] Version numbers are correct
+- [ ] PR approved and ready to merge
+
+Once merged, run `/publish-release` to tag, build, and push to NuGet.
+EOF
+)"
+```
+
+Show the user the PR URL.
+
+---
+
+## Summary Checklist
+
+- [ ] Branch `release/X.Y.Z` created from latest master
+- [ ] CHANGELOG.md updated with release entry
+- [ ] `pimpmychangelog` run
+- [ ] `<PackageVersion>` and `<Version>` bumped in csproj
+- [ ] Commit pushed to `release/X.Y.Z`
+- [ ] PR opened targeting master

--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -12,7 +12,7 @@ Create a release branch with version bump and changelog, then open a PR for revi
 
 ## Step 1: Confirm Version
 
-If the user did not supply a version number, read `src/StatsdClient/StatsdClient.csproj` and show the current `<PackageVersion>`. Ask: "Prepare release for X.Y.Z?" and wait for confirmation before proceeding.
+If the user did not supply a version number, read `src/StatsdClient/StatsdClient.csproj` and show the current version. Use `<PackageVersion>` if present; otherwise fall back to `<Version>`. Ask: "Prepare release for X.Y.Z?" and wait for confirmation before proceeding.
 
 ---
 

--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -29,12 +29,23 @@ Re-read `<PackageVersion>` from `src/StatsdClient/StatsdClient.csproj` and verif
 
 ---
 
-## Step 3: Tag the Release
+## Step 3: Tag the Release and Publish GitHub Release
+
+Use `gh release create` — creates the tag, pushes it, and publishes a GitHub Release in one step.
+
+Extract the X.Y.Z section from `CHANGELOG.md` into a temp file (everything between the `## X.Y.Z` heading and the next `## ` heading), then:
 
 ```bash
-git tag X.Y.Z
-git push origin X.Y.Z
+gh release create X.Y.Z --target master --title "X.Y.Z" --notes-file <changelog-section-file>
 ```
+
+If extraction is awkward, fall back to `--generate-notes` (auto from commits/PRs):
+
+```bash
+gh release create X.Y.Z --target master --title "X.Y.Z" --generate-notes
+```
+
+Verify tag pushed: `git fetch --tags && git tag -l X.Y.Z`.
 
 ---
 
@@ -79,7 +90,8 @@ dotnet nuget push artifacts/nuget/DogStatsD-CSharp-Client.X.Y.Z.snupkg \
 ## Summary Checklist
 
 - [ ] On latest master with release commit at HEAD
-- [ ] Git tag X.Y.Z created and pushed
+- [ ] Git tag X.Y.Z created and pushed via `gh release create`
+- [ ] GitHub Release X.Y.Z published with notes
 - [ ] `dotnet pack` succeeded, .nupkg exists
 - [ ] .nupkg pushed to NuGet.org
 - [ ] .snupkg (symbols) pushed to NuGet.org

--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -25,7 +25,7 @@ git checkout master
 git pull origin master
 ```
 
-Verify the top commit is the release commit (message should be "Release version X.Y.Z"). If it is not, stop and tell the user to ensure the release PR is merged before running this skill.
+Re-read `<PackageVersion>` from `src/StatsdClient/StatsdClient.csproj` and verify it still matches X.Y.Z. If it does not, stop and tell the user to ensure the release PR is merged before running this skill.
 
 ---
 

--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: publish-release
+description: "Publish a merged DogStatsD C# client release. Tags the merged master commit, pushes the tag, builds the NuGet package, and uploads to NuGet.org. Run after the release PR is merged. Triggers on: publish release, push to nuget, tag release, ship release."
+user-invocable: true
+---
+
+# Publish Release
+
+Tag the merged release, build the NuGet package, and push to NuGet.org.
+
+**Pre-condition:** The release PR must already be merged into master before running this.
+
+---
+
+## Step 1: Confirm Version
+
+Read the version from `src/StatsdClient/StatsdClient.csproj` (`<PackageVersion>`). Show it to the user and confirm: "Publish release X.Y.Z?" before proceeding.
+
+---
+
+## Step 2: Switch to Master and Pull
+
+```bash
+git checkout master
+git pull origin master
+```
+
+Verify the top commit is the release commit (message should be "Release version X.Y.Z"). If it is not, stop and tell the user to ensure the release PR is merged before running this skill.
+
+---
+
+## Step 3: Tag the Release
+
+```bash
+git tag X.Y.Z
+git push origin X.Y.Z
+```
+
+---
+
+## Step 4: Build NuGet Package
+
+```bash
+dotnet pack src/StatsdClient/StatsdClient.csproj -c Release -o artifacts/nuget
+```
+
+Verify the command exits 0 and that `artifacts/nuget/DogStatsD-CSharp-Client.X.Y.Z.nupkg` exists.
+
+---
+
+## Step 5: Push to NuGet.org
+
+**Pause here.** Ask the user:
+
+> "Ready to push `DogStatsD-CSharp-Client.X.Y.Z.nupkg` to NuGet.org. Is `NUGET_API_KEY` set? Proceed?"
+
+Only run after explicit confirmation.
+
+Push the main package:
+
+```bash
+dotnet nuget push artifacts/nuget/DogStatsD-CSharp-Client.X.Y.Z.nupkg \
+  --api-key "$NUGET_API_KEY" \
+  --source https://api.nuget.org/v3/index.json \
+  --skip-duplicate
+```
+
+Push symbols if present:
+
+```bash
+dotnet nuget push artifacts/nuget/DogStatsD-CSharp-Client.X.Y.Z.snupkg \
+  --api-key "$NUGET_API_KEY" \
+  --source https://api.nuget.org/v3/index.json \
+  --skip-duplicate
+```
+
+---
+
+## Summary Checklist
+
+- [ ] On latest master with release commit at HEAD
+- [ ] Git tag X.Y.Z created and pushed
+- [ ] `dotnet pack` succeeded, .nupkg exists
+- [ ] .nupkg pushed to NuGet.org
+- [ ] .snupkg (symbols) pushed to NuGet.org


### PR DESCRIPTION
Largely following the release process outlined [here](https://datadoghq.atlassian.net/wiki/spaces/AM/pages/2523399106/DogStatsD-CSharp-Client) add a couple of skills.

1. prepare the release (#228 is the first example of this)
2. push the new release to nuget