### PR TITLE
Release 9.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+# 9.2.0 / 2026-06-10
+
+## Changes
+
+* [IMPROVEMENT] Use default scheduler for worker tasks. See [#205][].
+* [IMPROVEMENT] Remove `Mono.Unix` dependency. See [#223][].
+
 # 9.1.0 / 2026-04-27
 
 ## Changes
@@ -291,9 +298,11 @@ DogStatsD-CSharp-Client `2.2.1` is the last version to support .NET Framework 3.
 [#186]: https://github.com/DataDog/dogstatsd-csharp-client/issues/186
 [#187]: https://github.com/DataDog/dogstatsd-csharp-client/issues/187
 [#188]: https://github.com/DataDog/dogstatsd-csharp-client/issues/188
+[#205]: https://github.com/DataDog/dogstatsd-csharp-client/issues/205
 [#209]: https://github.com/DataDog/dogstatsd-csharp-client/issues/209
 [#211]: https://github.com/DataDog/dogstatsd-csharp-client/issues/211
 [#213]: https://github.com/DataDog/dogstatsd-csharp-client/issues/213
+[#223]: https://github.com/DataDog/dogstatsd-csharp-client/issues/223
 [#227]: https://github.com/DataDog/dogstatsd-csharp-client/issues/227
 [@DanielVukelich]: https://github.com/DanielVukelich
 [@albertofem]: https://github.com/albertofem

--- a/src/StatsdClient/StatsdClient.csproj
+++ b/src/StatsdClient/StatsdClient.csproj
@@ -4,7 +4,7 @@
     <PackageId>DogStatsD-CSharp-Client</PackageId>
     <TargetFrameworks>net461;netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
-    <PackageVersion>9.1.0</PackageVersion>
+    <PackageVersion>9.2.0</PackageVersion>
     <Version>9.0.0</Version>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>StatsdClient.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
## Release 9.2.0

Changelog and version bump for the 9.2.0 NuGet release.

### Checklist
- [ ] Changelog entries are accurate
- [ ] Version numbers are correct
- [ ] PR approved and ready to merge

Once merged, run `/publish-release` to tag, build, and push to NuGet.