### PR TITLE
SLES-2913: prevent named pipe failures from eating the whole thread pool

### DIFF
--- a/src/StatsdClient/Telemetry.cs
+++ b/src/StatsdClient/Telemetry.cs
@@ -180,6 +180,11 @@ namespace StatsdClient
         {
             lock (_timerLock)
             {
+                if (_disposed)
+                {
+                    return;
+                }
+
                 _disposed = true;
                 _optionalTimer?.Change(Timeout.Infinite, Timeout.Infinite);
                 _optionalTimer?.Dispose();

--- a/src/StatsdClient/Telemetry.cs
+++ b/src/StatsdClient/Telemetry.cs
@@ -14,11 +14,14 @@ namespace StatsdClient
     {
         private static string _telemetryPrefix = "datadog.dogstatsd.client.";
         private readonly Timer _optionalTimer;
+        private readonly TimeSpan _flushInterval;
+        private readonly object _timerLock = new object();
         private readonly string[] _optionalTags;
         private readonly MetricSerializer _optionalMetricSerializer;
         private readonly ITransport _optionalTransport;
         private readonly Dictionary<MetricType, ValueWithTags> _aggregatedContexts = new Dictionary<MetricType, ValueWithTags>();
         private readonly Action<Exception> _optionalExceptionHandler;
+        private bool _disposed;
 
         private int _metricsSent;
         private int _eventsSent;
@@ -54,13 +57,18 @@ namespace StatsdClient
             _aggregatedContexts.Add(MetricType.Count, new ValueWithTags(_optionalTags, "metrics_type:count"));
             _aggregatedContexts.Add(MetricType.Set, new ValueWithTags(_optionalTags, "metrics_type:set"));
             _optionalExceptionHandler = optionalExceptionHandler;
+            _flushInterval = flushInterval;
             if (!synchronousMode)
             {
+                // One-shot timer re-armed at the end of each flush (see OnTimerFlush) so that
+                // at most one flush runs at a time. A periodic timer would keep dispatching
+                // callbacks onto the thread pool even while a flush is blocked on a stalled
+                // transport, growing the thread count without bound.
                 _optionalTimer = new Timer(
-                    _ => Flush(),
+                    _ => OnTimerFlush(),
                     null,
                     flushInterval,
-                    flushInterval);
+                    Timeout.InfiniteTimeSpan);
             }
         }
 
@@ -170,8 +178,33 @@ namespace StatsdClient
 
         public void Dispose()
         {
-            _optionalTimer?.Change(Timeout.Infinite, Timeout.Infinite);
-            _optionalTimer?.Dispose();
+            lock (_timerLock)
+            {
+                _disposed = true;
+                _optionalTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+                _optionalTimer?.Dispose();
+            }
+        }
+
+        private void OnTimerFlush()
+        {
+            try
+            {
+                Flush();
+            }
+            finally
+            {
+                // Re-arm the one-shot timer only after this flush finishes, so flushes cannot overlap.
+                // Dispose sets _disposed and disposes the timer under the same lock, so while _disposed
+                // is false the timer is still alive.
+                lock (_timerLock)
+                {
+                    if (!_disposed)
+                    {
+                        _optionalTimer?.Change(_flushInterval, Timeout.InfiniteTimeSpan);
+                    }
+                }
+            }
         }
 
         private void SendMetricWithTags(string metricName, string[] tags, int value)

--- a/src/StatsdClient/Telemetry.cs
+++ b/src/StatsdClient/Telemetry.cs
@@ -21,7 +21,7 @@ namespace StatsdClient
         private readonly ITransport _optionalTransport;
         private readonly Dictionary<MetricType, ValueWithTags> _aggregatedContexts = new Dictionary<MetricType, ValueWithTags>();
         private readonly Action<Exception> _optionalExceptionHandler;
-        private bool _disposed;
+        private volatile bool _disposed;
 
         private int _metricsSent;
         private int _eventsSent;

--- a/src/StatsdClient/Telemetry.cs
+++ b/src/StatsdClient/Telemetry.cs
@@ -188,6 +188,14 @@ namespace StatsdClient
 
         private void OnTimerFlush()
         {
+            // A one-shot callback can already be in flight when Dispose runs, so skip the flush
+            // if the timer has been disposed. The check runs without holding _timerLock so it
+            // never blocks Dispose.
+            if (_disposed)
+            {
+                return;
+            }
+
             try
             {
                 Flush();

--- a/src/StatsdClient/Transport/NamedPipeTransport.cs
+++ b/src/StatsdClient/Transport/NamedPipeTransport.cs
@@ -9,14 +9,17 @@ namespace StatsdClient.Transport
     {
         private readonly NamedPipeClientStream _namedPipe;
         private readonly TimeSpan _timeout;
+        private readonly TimeSpan _connectionCooldown;
+        private readonly System.Diagnostics.Stopwatch _connectFailureTimer = new System.Diagnostics.Stopwatch();
         private readonly object _lock = new object();
 
         private byte[] _internalbuffer = Array.Empty<byte>();
 
-        public NamedPipeTransport(string pipeName, TimeSpan? timeout = null)
+        public NamedPipeTransport(string pipeName, TimeSpan? timeout = null, TimeSpan? connectionCooldown = null)
         {
             _namedPipe = new NamedPipeClientStream(".", pipeName, PipeDirection.Out, PipeOptions.Asynchronous);
             _timeout = timeout ?? TimeSpan.FromSeconds(2);
+            _connectionCooldown = connectionCooldown ?? TimeSpan.FromSeconds(5);
         }
 
         public TransportType TransportType => TransportType.NamedPipe;
@@ -51,11 +54,22 @@ namespace StatsdClient.Transport
             {
                 if (!_namedPipe.IsConnected)
                 {
+                    // After a failed connect, avoid blocking on Connect again until the
+                    // cooldown elapses. Otherwise every send re-blocks for the full timeout
+                    // while the pipe is unavailable, starving the worker and (through the
+                    // telemetry timer) inflating the thread count.
+                    if (_connectFailureTimer.IsRunning && _connectFailureTimer.Elapsed < _connectionCooldown)
+                    {
+                        return false;
+                    }
+
                     _namedPipe.Connect((int)_timeout.TotalMilliseconds);
+                    _connectFailureTimer.Reset();
                 }
             }
             catch (TimeoutException)
             {
+                _connectFailureTimer.Restart();
                 return false;
             }
 

--- a/src/StatsdClient/Transport/NamedPipeTransport.cs
+++ b/src/StatsdClient/Transport/NamedPipeTransport.cs
@@ -97,6 +97,20 @@ namespace StatsdClient.Transport
                 _sendFailureTimer.Restart();
                 return false;
             }
+            catch (IOException)
+            {
+                // A missing or busy pipe fails the connect with IOException rather than
+                // TimeoutException. Start the cooldown so subsequent sends fail fast instead
+                // of re-blocking on Connect.
+                _sendFailureTimer.Restart();
+                return false;
+            }
+            catch (AggregateException e) when (e.InnerException is IOException)
+            {
+                // dotnet6.0 raises AggregateException when an IOException occurs.
+                _sendFailureTimer.Restart();
+                return false;
+            }
 
             try
             {

--- a/src/StatsdClient/Transport/NamedPipeTransport.cs
+++ b/src/StatsdClient/Transport/NamedPipeTransport.cs
@@ -2,22 +2,25 @@ using System;
 using System.IO;
 using System.IO.Pipes;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace StatsdClient.Transport
 {
     internal class NamedPipeTransport : ITransport
     {
-        private readonly NamedPipeClientStream _namedPipe;
+        private readonly string _pipeName;
         private readonly TimeSpan _timeout;
         private readonly TimeSpan _connectionCooldown;
         private readonly System.Diagnostics.Stopwatch _sendFailureTimer = new System.Diagnostics.Stopwatch();
         private readonly object _lock = new object();
 
+        private NamedPipeClientStream _namedPipe;
         private byte[] _internalbuffer = Array.Empty<byte>();
 
         public NamedPipeTransport(string pipeName, TimeSpan? timeout = null, TimeSpan? connectionCooldown = null)
         {
-            _namedPipe = new NamedPipeClientStream(".", pipeName, PipeDirection.Out, PipeOptions.Asynchronous);
+            _pipeName = pipeName;
+            _namedPipe = CreatePipe();
             _timeout = timeout ?? TimeSpan.FromSeconds(2);
             _connectionCooldown = connectionCooldown ?? TimeSpan.FromSeconds(5);
         }
@@ -48,6 +51,23 @@ namespace StatsdClient.Transport
             _namedPipe.Dispose();
         }
 
+        private NamedPipeClientStream CreatePipe()
+        {
+            return new NamedPipeClientStream(".", _pipeName, PipeDirection.Out, PipeOptions.Asynchronous);
+        }
+
+        private void ResetPipeAfterAbandonedWrite(Task abandonedWrite)
+        {
+            // The abandoned write is fire-and-forget now. Observe its eventual fault so tearing
+            // down the disposed pipe does not surface as an unobserved task exception.
+            abandonedWrite.ContinueWith(
+                t => { _ = t.Exception; },
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+
+            _namedPipe.Dispose();
+            _namedPipe = CreatePipe();
+        }
+
         private bool SendBuffer(byte[] buffer, int length, bool allowRetry)
         {
             // After a failed send, fail fast until the cooldown elapses instead of blocking
@@ -75,16 +95,22 @@ namespace StatsdClient.Transport
 
             try
             {
-                // WriteAsync overload with a CancellationToken instance seems to not work.
-                if (_namedPipe.WriteAsync(buffer, 0, length).Wait(_timeout))
+                // TODO: Blocking on an async Task with Wait() is bad practice and can deadlock;
+                // this should move to an async send path. The WriteAsync overload with a
+                // CancellationToken instance seems to not work, so the write cannot be cancelled.
+                var writeTask = _namedPipe.WriteAsync(buffer, 0, length);
+                if (writeTask.Wait(_timeout))
                 {
                     _sendFailureTimer.Reset();
                     return true;
                 }
 
-                // The write timed out. The pipe still reports connected, so cool down to
+                // The write timed out. WriteAsync keeps running against the pipe with no way to
+                // cancel it, so abandon the stalled write and recreate the pipe: the next send
+                // reconnects cleanly instead of racing the orphaned write. Cool down first to
                 // avoid re-blocking for the full timeout on every subsequent send.
                 _sendFailureTimer.Restart();
+                ResetPipeAfterAbandonedWrite(writeTask);
                 return false;
             }
             catch (IOException)

--- a/src/StatsdClient/Transport/NamedPipeTransport.cs
+++ b/src/StatsdClient/Transport/NamedPipeTransport.cs
@@ -48,7 +48,10 @@ namespace StatsdClient.Transport
 
         public void Dispose()
         {
-            _namedPipe.Dispose();
+            lock (_lock)
+            {
+                _namedPipe.Dispose();
+            }
         }
 
         private NamedPipeClientStream CreatePipe()
@@ -62,7 +65,9 @@ namespace StatsdClient.Transport
             // down the disposed pipe does not surface as an unobserved task exception.
             abandonedWrite.ContinueWith(
                 t => { _ = t.Exception; },
-                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
 
             _namedPipe.Dispose();
             _namedPipe = CreatePipe();

--- a/src/StatsdClient/Transport/NamedPipeTransport.cs
+++ b/src/StatsdClient/Transport/NamedPipeTransport.cs
@@ -10,7 +10,7 @@ namespace StatsdClient.Transport
         private readonly NamedPipeClientStream _namedPipe;
         private readonly TimeSpan _timeout;
         private readonly TimeSpan _connectionCooldown;
-        private readonly System.Diagnostics.Stopwatch _connectFailureTimer = new System.Diagnostics.Stopwatch();
+        private readonly System.Diagnostics.Stopwatch _sendFailureTimer = new System.Diagnostics.Stopwatch();
         private readonly object _lock = new object();
 
         private byte[] _internalbuffer = Array.Empty<byte>();
@@ -50,33 +50,42 @@ namespace StatsdClient.Transport
 
         private bool SendBuffer(byte[] buffer, int length, bool allowRetry)
         {
+            // After a failed send, fail fast until the cooldown elapses instead of blocking
+            // again on Connect or Write. Otherwise every send re-blocks for the full timeout
+            // while the pipe is unavailable, starving the worker and (through the telemetry
+            // timer) inflating the thread count. The gate sits ahead of the connection check
+            // so a connected-but-stalled pipe (writes timing out) is throttled too.
+            if (_sendFailureTimer.IsRunning && _sendFailureTimer.Elapsed < _connectionCooldown)
+            {
+                return false;
+            }
+
             try
             {
                 if (!_namedPipe.IsConnected)
                 {
-                    // After a failed connect, avoid blocking on Connect again until the
-                    // cooldown elapses. Otherwise every send re-blocks for the full timeout
-                    // while the pipe is unavailable, starving the worker and (through the
-                    // telemetry timer) inflating the thread count.
-                    if (_connectFailureTimer.IsRunning && _connectFailureTimer.Elapsed < _connectionCooldown)
-                    {
-                        return false;
-                    }
-
                     _namedPipe.Connect((int)_timeout.TotalMilliseconds);
-                    _connectFailureTimer.Reset();
                 }
             }
             catch (TimeoutException)
             {
-                _connectFailureTimer.Restart();
+                _sendFailureTimer.Restart();
                 return false;
             }
 
             try
             {
                 // WriteAsync overload with a CancellationToken instance seems to not work.
-                return _namedPipe.WriteAsync(buffer, 0, length).Wait(_timeout);
+                if (_namedPipe.WriteAsync(buffer, 0, length).Wait(_timeout))
+                {
+                    _sendFailureTimer.Reset();
+                    return true;
+                }
+
+                // The write timed out. The pipe still reports connected, so cool down to
+                // avoid re-blocking for the full timeout on every subsequent send.
+                _sendFailureTimer.Restart();
+                return false;
             }
             catch (IOException)
             {
@@ -93,6 +102,7 @@ namespace StatsdClient.Transport
                 return SendBuffer(buffer, length, allowRetry: false);
             }
 
+            _sendFailureTimer.Restart();
             return false;
         }
     }

--- a/tests/StatsdClient.Tests/TelemetryTests.cs
+++ b/tests/StatsdClient.Tests/TelemetryTests.cs
@@ -220,6 +220,10 @@ namespace Tests
                 // Always release the blocked flush callback so a failed assertion above does not
                 // leave a thread-pool thread parked on releaseFlush for the rest of the run.
                 releaseFlush.Set();
+
+                // Dispose here too so a failed assertion before the in-test Dispose does not leave
+                // the timer running and leak into subsequent tests. Dispose is idempotent.
+                telemetry.Dispose();
             }
 
             // Let the in-flight flush finish and attempt to re-arm after Dispose; it must not throw.

--- a/tests/StatsdClient.Tests/TelemetryTests.cs
+++ b/tests/StatsdClient.Tests/TelemetryTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using Moq;
 using NUnit.Framework;
 using StatsdClient;
@@ -129,6 +130,94 @@ namespace Tests
                 "datadog.dogstatsd.client.metrics:1|c|#" +
                 "client:csharp,client_version:1.0.0.0,client_transport:uds," +
                 "globalTagKey:globalTagValue", _metrics[0]);
+        }
+
+        [Test]
+        public void FlushesDoNotOverlap()
+        {
+            var concurrencyLock = new object();
+            int concurrentSends = 0;
+            int maxConcurrentSends = 0;
+
+            var transport = new Mock<ITransport>();
+            transport.SetupGet(s => s.TelemetryClientTransport).Returns("uds");
+            transport.Setup(s => s.Send(It.IsAny<byte[]>(), It.IsAny<int>()))
+                .Callback<byte[], int>((bytes, l) =>
+                {
+                    lock (concurrencyLock)
+                    {
+                        concurrentSends++;
+                        maxConcurrentSends = Math.Max(maxConcurrentSends, concurrentSends);
+                    }
+
+                    // Make a flush slow relative to the interval so overlapping callbacks would
+                    // be observable if the timer were still periodic.
+                    Thread.Sleep(20);
+
+                    lock (concurrencyLock)
+                    {
+                        concurrentSends--;
+                    }
+                });
+
+            using (new Telemetry(
+                new MetricSerializer(new SerializerHelper(null, null), string.Empty),
+                "1.0.0.0",
+                TimeSpan.FromMilliseconds(50),
+                transport.Object,
+                Array.Empty<string>(),
+                Tools.ExceptionHandler))
+            {
+                Thread.Sleep(TimeSpan.FromSeconds(1));
+            }
+
+            // A single flush sends sequentially on one thread, so concurrency stays 1 unless
+            // two flushes ran at once.
+            Assert.AreEqual(1, maxConcurrentSends);
+        }
+
+        [Test]
+        public void DisposeDoesNotDeadlockDuringInFlightFlush()
+        {
+            Exception caughtException = null;
+            int firstSend = 1;
+            var flushStarted = new ManualResetEventSlim(false);
+            var releaseFlush = new ManualResetEventSlim(false);
+
+            var transport = new Mock<ITransport>();
+            transport.SetupGet(s => s.TelemetryClientTransport).Returns("uds");
+            transport.Setup(s => s.Send(It.IsAny<byte[]>(), It.IsAny<int>()))
+                .Callback<byte[], int>((bytes, l) =>
+                {
+                    // Hold the first flush open so Dispose runs while a flush is in flight.
+                    if (Interlocked.Exchange(ref firstSend, 0) == 1)
+                    {
+                        flushStarted.Set();
+                        releaseFlush.Wait();
+                    }
+                });
+
+            var telemetry = new Telemetry(
+                new MetricSerializer(new SerializerHelper(null, null), string.Empty),
+                "1.0.0.0",
+                TimeSpan.FromMilliseconds(20),
+                transport.Object,
+                Array.Empty<string>(),
+                e => caughtException = e);
+
+            Assert.True(flushStarted.Wait(TimeSpan.FromSeconds(5)), "timer never dispatched a flush");
+
+            // Dispose must complete without waiting for the in-flight flush: the flush holds no lock
+            // while blocked in the transport, and the re-arm only takes _timerLock after the flush ends.
+            var disposeThread = new Thread(() => telemetry.Dispose());
+            disposeThread.Start();
+            Assert.True(disposeThread.Join(TimeSpan.FromSeconds(5)), "Dispose deadlocked while a flush was in flight");
+
+            // Let the in-flight flush finish and attempt to re-arm after Dispose; it must not throw.
+            releaseFlush.Set();
+            Thread.Sleep(50);
+
+            Assert.IsNull(caughtException);
         }
 
         private void AssertTelemetryReceived(Dictionary<string, int> expectedResults)

--- a/tests/StatsdClient.Tests/TelemetryTests.cs
+++ b/tests/StatsdClient.Tests/TelemetryTests.cs
@@ -205,16 +205,24 @@ namespace Tests
                 Array.Empty<string>(),
                 e => caughtException = e);
 
-            Assert.True(flushStarted.Wait(TimeSpan.FromSeconds(5)), "timer never dispatched a flush");
+            try
+            {
+                Assert.True(flushStarted.Wait(TimeSpan.FromSeconds(5)), "timer never dispatched a flush");
 
-            // Dispose must complete without waiting for the in-flight flush: the flush holds no lock
-            // while blocked in the transport, and the re-arm only takes _timerLock after the flush ends.
-            var disposeThread = new Thread(() => telemetry.Dispose());
-            disposeThread.Start();
-            Assert.True(disposeThread.Join(TimeSpan.FromSeconds(5)), "Dispose deadlocked while a flush was in flight");
+                // Dispose must complete without waiting for the in-flight flush: the flush holds no lock
+                // while blocked in the transport, and the re-arm only takes _timerLock after the flush ends.
+                var disposeThread = new Thread(() => telemetry.Dispose());
+                disposeThread.Start();
+                Assert.True(disposeThread.Join(TimeSpan.FromSeconds(5)), "Dispose deadlocked while a flush was in flight");
+            }
+            finally
+            {
+                // Always release the blocked flush callback so a failed assertion above does not
+                // leave a thread-pool thread parked on releaseFlush for the rest of the run.
+                releaseFlush.Set();
+            }
 
             // Let the in-flight flush finish and attempt to re-arm after Dispose; it must not throw.
-            releaseFlush.Set();
             Thread.Sleep(50);
 
             Assert.IsNull(caughtException);

--- a/tests/StatsdClient.Tests/Transport/NamedPipeTransportTests.cs
+++ b/tests/StatsdClient.Tests/Transport/NamedPipeTransportTests.cs
@@ -101,10 +101,12 @@ namespace Tests
 
                 var cooldownSendsDuration = stopwatch.Elapsed;
 
-                // The first send pays the connect timeout; subsequent sends within the
-                // cooldown fail fast instead of each blocking on Connect again. Assert
-                // relative to the configured timeout so the test tolerates slow/noisy CI.
-                Assert.That(firstSendDuration, Is.GreaterThan(TimeSpan.FromMilliseconds(connectTimeout.TotalMilliseconds * 0.5)));
+                // Subsequent sends within the cooldown must fail fast instead of each blocking
+                // on Connect again. Assert the whole batch completes in a small fraction of a
+                // single connect timeout so the test fails if sends keep blocking, without
+                // relying on Connect actually blocking the full timeout (some Windows/.NET
+                // combinations fail a missing pipe quickly).
+                Assert.That(cooldownSendsDuration, Is.LessThan(TimeSpan.FromMilliseconds(connectTimeout.TotalMilliseconds * 0.5)));
                 Assert.That(cooldownSendsDuration, Is.LessThan(firstSendDuration));
             }
         }
@@ -153,10 +155,10 @@ namespace Tests
 
                     var cooldownSendsDuration = stopwatch.Elapsed;
 
-                    // The first send pays the write timeout; subsequent sends within the cooldown
-                    // fail fast instead of each blocking on the stalled write again. Assert
-                    // relative to the configured timeout so the test tolerates slow/noisy CI.
-                    Assert.That(firstSendDuration, Is.GreaterThan(TimeSpan.FromMilliseconds(timeout.TotalMilliseconds * 0.5)));
+                    // Subsequent sends within the cooldown must fail fast instead of each blocking
+                    // on the stalled write again. Assert the whole batch completes in a small
+                    // fraction of a single write timeout so the test fails if sends keep blocking.
+                    Assert.That(cooldownSendsDuration, Is.LessThan(TimeSpan.FromMilliseconds(timeout.TotalMilliseconds * 0.5)));
                     Assert.That(cooldownSendsDuration, Is.LessThan(firstSendDuration));
                 }
             }

--- a/tests/StatsdClient.Tests/Transport/NamedPipeTransportTests.cs
+++ b/tests/StatsdClient.Tests/Transport/NamedPipeTransportTests.cs
@@ -87,7 +87,7 @@ namespace Tests
             var cooldown = TimeSpan.FromSeconds(10);
 
             // No server listens on this pipe, so Connect blocks for the full timeout and fails.
-            using (var transport = new NamedPipeTransport("cooldownPipeNameTest", connectTimeout, cooldown))
+            using (var transport = new NamedPipeTransport("cooldownPipeNameTest-" + Guid.NewGuid(), connectTimeout, cooldown))
             {
                 var stopwatch = Stopwatch.StartNew();
                 Assert.False(transport.Send(_buffToSend, _buffToSend.Length));
@@ -114,7 +114,7 @@ namespace Tests
         {
             var timeout = TimeSpan.FromSeconds(1);
             var cooldown = TimeSpan.FromSeconds(10);
-            var pipeName = "writeCooldownPipeNameTest";
+            var pipeName = "writeCooldownPipeNameTest-" + Guid.NewGuid();
             var releaseServer = new ManualResetEventSlim(false);
 
             // The server connects but never reads, so its buffer fills and the client's

--- a/tests/StatsdClient.Tests/Transport/NamedPipeTransportTests.cs
+++ b/tests/StatsdClient.Tests/Transport/NamedPipeTransportTests.cs
@@ -91,7 +91,6 @@ namespace Tests
             {
                 var stopwatch = Stopwatch.StartNew();
                 Assert.False(transport.Send(_buffToSend, _buffToSend.Length));
-                var firstSendDuration = stopwatch.Elapsed;
 
                 stopwatch.Restart();
                 for (int i = 0; i < 5; i++)
@@ -107,7 +106,6 @@ namespace Tests
                 // relying on Connect actually blocking the full timeout (some Windows/.NET
                 // combinations fail a missing pipe quickly).
                 Assert.That(cooldownSendsDuration, Is.LessThan(TimeSpan.FromMilliseconds(connectTimeout.TotalMilliseconds * 0.5)));
-                Assert.That(cooldownSendsDuration, Is.LessThan(firstSendDuration));
             }
         }
 
@@ -141,11 +139,12 @@ namespace Tests
             {
                 using (var transport = new NamedPipeTransport(pipeName, timeout, cooldown))
                 {
-                    var buff = new byte[_serverBufferSize * 10];
+                    // The OS may round the server's requested buffer size up, so use a payload
+                    // far larger than the requested buffer to make the stalled write reliable.
+                    var buff = new byte[_serverBufferSize * 1000];
 
                     var stopwatch = Stopwatch.StartNew();
                     Assert.False(transport.Send(buff, buff.Length));
-                    var firstSendDuration = stopwatch.Elapsed;
 
                     stopwatch.Restart();
                     for (int i = 0; i < 5; i++)
@@ -159,7 +158,6 @@ namespace Tests
                     // on the stalled write again. Assert the whole batch completes in a small
                     // fraction of a single write timeout so the test fails if sends keep blocking.
                     Assert.That(cooldownSendsDuration, Is.LessThan(TimeSpan.FromMilliseconds(timeout.TotalMilliseconds * 0.5)));
-                    Assert.That(cooldownSendsDuration, Is.LessThan(firstSendDuration));
                 }
             }
             finally

--- a/tests/StatsdClient.Tests/Transport/NamedPipeTransportTests.cs
+++ b/tests/StatsdClient.Tests/Transport/NamedPipeTransportTests.cs
@@ -1,5 +1,6 @@
 #if OS_WINDOWS
 using System;
+using System.Diagnostics;
 using System.IO.Pipes;
 using System.Threading;
 using System.Threading.Tasks;
@@ -76,6 +77,34 @@ namespace Tests
                     Assert.True(transport.Send(_buffToSend, _buffToSend.Length));
                     CollectionAssert.AreEqual(task.Result, _buffToSend);
                 }
+            }
+        }
+
+        [Test]
+        public void ConnectionCooldownAvoidsRepeatedBlocking()
+        {
+            var connectTimeout = TimeSpan.FromSeconds(1);
+            var cooldown = TimeSpan.FromSeconds(10);
+
+            // No server listens on this pipe, so Connect blocks for the full timeout and fails.
+            using (var transport = new NamedPipeTransport("cooldownPipeNameTest", connectTimeout, cooldown))
+            {
+                var stopwatch = Stopwatch.StartNew();
+                Assert.False(transport.Send(_buffToSend, _buffToSend.Length));
+                var firstSendDuration = stopwatch.Elapsed;
+
+                stopwatch.Restart();
+                for (int i = 0; i < 5; i++)
+                {
+                    Assert.False(transport.Send(_buffToSend, _buffToSend.Length));
+                }
+
+                var cooldownSendsDuration = stopwatch.Elapsed;
+
+                // The first send pays the connect timeout; subsequent sends within the
+                // cooldown fail fast instead of each blocking on Connect again.
+                Assert.That(firstSendDuration, Is.GreaterThan(TimeSpan.FromMilliseconds(500)));
+                Assert.That(cooldownSendsDuration, Is.LessThan(TimeSpan.FromMilliseconds(500)));
             }
         }
 

--- a/tests/StatsdClient.Tests/Transport/NamedPipeTransportTests.cs
+++ b/tests/StatsdClient.Tests/Transport/NamedPipeTransportTests.cs
@@ -108,6 +108,58 @@ namespace Tests
             }
         }
 
+        [Test]
+        public void WriteTimeoutTriggersCooldown()
+        {
+            var timeout = TimeSpan.FromSeconds(1);
+            var cooldown = TimeSpan.FromSeconds(10);
+            var pipeName = "writeCooldownPipeNameTest";
+            var releaseServer = new ManualResetEventSlim(false);
+
+            // The server connects but never reads, so its buffer fills and the client's
+            // write stalls until it times out.
+            var serverTask = Task.Run(() =>
+            {
+                using (var serverStream = new NamedPipeServerStream(
+                            pipeName,
+                            PipeDirection.In,
+                            1,
+                            PipeTransmissionMode.Byte,
+                            PipeOptions.Asynchronous,
+                            _serverBufferSize,
+                            0))
+                {
+                    serverStream.WaitForConnection();
+                    releaseServer.Wait();
+                }
+            });
+
+            using (var transport = new NamedPipeTransport(pipeName, timeout, cooldown))
+            {
+                var buff = new byte[_serverBufferSize * 10];
+
+                var stopwatch = Stopwatch.StartNew();
+                Assert.False(transport.Send(buff, buff.Length));
+                var firstSendDuration = stopwatch.Elapsed;
+
+                stopwatch.Restart();
+                for (int i = 0; i < 5; i++)
+                {
+                    Assert.False(transport.Send(buff, buff.Length));
+                }
+
+                var cooldownSendsDuration = stopwatch.Elapsed;
+
+                // The first send pays the write timeout; subsequent sends within the cooldown
+                // fail fast instead of each blocking on the stalled write again.
+                Assert.That(firstSendDuration, Is.GreaterThan(TimeSpan.FromMilliseconds(500)));
+                Assert.That(cooldownSendsDuration, Is.LessThan(TimeSpan.FromMilliseconds(500)));
+            }
+
+            releaseServer.Set();
+            serverTask.Wait();
+        }
+
         private Task<byte[]> StartServerSingleRead(int bufferSize)
         {
             return StartServer(server =>

--- a/tests/StatsdClient.Tests/Transport/NamedPipeTransportTests.cs
+++ b/tests/StatsdClient.Tests/Transport/NamedPipeTransportTests.cs
@@ -102,9 +102,10 @@ namespace Tests
                 var cooldownSendsDuration = stopwatch.Elapsed;
 
                 // The first send pays the connect timeout; subsequent sends within the
-                // cooldown fail fast instead of each blocking on Connect again.
-                Assert.That(firstSendDuration, Is.GreaterThan(TimeSpan.FromMilliseconds(500)));
-                Assert.That(cooldownSendsDuration, Is.LessThan(TimeSpan.FromMilliseconds(500)));
+                // cooldown fail fast instead of each blocking on Connect again. Assert
+                // relative to the configured timeout so the test tolerates slow/noisy CI.
+                Assert.That(firstSendDuration, Is.GreaterThan(TimeSpan.FromMilliseconds(connectTimeout.TotalMilliseconds * 0.5)));
+                Assert.That(cooldownSendsDuration, Is.LessThan(firstSendDuration));
             }
         }
 
@@ -134,30 +135,36 @@ namespace Tests
                 }
             });
 
-            using (var transport = new NamedPipeTransport(pipeName, timeout, cooldown))
+            try
             {
-                var buff = new byte[_serverBufferSize * 10];
-
-                var stopwatch = Stopwatch.StartNew();
-                Assert.False(transport.Send(buff, buff.Length));
-                var firstSendDuration = stopwatch.Elapsed;
-
-                stopwatch.Restart();
-                for (int i = 0; i < 5; i++)
+                using (var transport = new NamedPipeTransport(pipeName, timeout, cooldown))
                 {
+                    var buff = new byte[_serverBufferSize * 10];
+
+                    var stopwatch = Stopwatch.StartNew();
                     Assert.False(transport.Send(buff, buff.Length));
+                    var firstSendDuration = stopwatch.Elapsed;
+
+                    stopwatch.Restart();
+                    for (int i = 0; i < 5; i++)
+                    {
+                        Assert.False(transport.Send(buff, buff.Length));
+                    }
+
+                    var cooldownSendsDuration = stopwatch.Elapsed;
+
+                    // The first send pays the write timeout; subsequent sends within the cooldown
+                    // fail fast instead of each blocking on the stalled write again. Assert
+                    // relative to the configured timeout so the test tolerates slow/noisy CI.
+                    Assert.That(firstSendDuration, Is.GreaterThan(TimeSpan.FromMilliseconds(timeout.TotalMilliseconds * 0.5)));
+                    Assert.That(cooldownSendsDuration, Is.LessThan(firstSendDuration));
                 }
-
-                var cooldownSendsDuration = stopwatch.Elapsed;
-
-                // The first send pays the write timeout; subsequent sends within the cooldown
-                // fail fast instead of each blocking on the stalled write again.
-                Assert.That(firstSendDuration, Is.GreaterThan(TimeSpan.FromMilliseconds(500)));
-                Assert.That(cooldownSendsDuration, Is.LessThan(TimeSpan.FromMilliseconds(500)));
             }
-
-            releaseServer.Set();
-            serverTask.Wait();
+            finally
+            {
+                releaseServer.Set();
+                Assert.True(serverTask.Wait(TimeSpan.FromSeconds(5)), "server task did not complete");
+            }
         }
 
         private Task<byte[]> StartServerSingleRead(int bufferSize)


### PR DESCRIPTION
`dogstatsd` in Azure App Services with the Windows Extension sometimes fail to correctly get a named pipe. This can happen when the app is hot-reloaded and the previous incarnation of `dogstatsd` hasn't released the named pipe when the new `dogstatsd` is starting up. This causes the named pipe writes from the dogstatsd client to fail (permanently, until the app is restarted again).

These failures cause a steady growth of threads as the telemetry timer spawns one every 10 seconds to try to write client telemetry, and the 2 second timeout for each of the 11 stats that the telemetry wants to send compounds to 22 seconds of work. Forever.

This change turns the telemetry timer into one that reschedules itself after every round, instead of spawning one every 10 seconds. It also adds a cooldown for sending telemetry, so that if there's a failure to send, we back off for a bit before trying to send any more.

This is one of a few different patches to address this issue. We also have https://github.com/DataDog/dd-trace-dotnet/pull/8874 for the app service extension process manager and https://github.com/DataDog/datadog-agent/pull/53328 for dogstatsd.