### PR TITLE
Release 9.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+# 9.2.1 / 2026-07-24
+
+## Changes
+
+* [BUGFIX] Prevent named pipe write failures from causing unbounded thread growth. The telemetry timer now reschedules itself after each round instead of spawning a new thread every 10s, and backs off after send failures. See [#231][].
+
 # 9.2.0 / 2026-06-10
 
 ## Changes
@@ -304,6 +310,7 @@ DogStatsD-CSharp-Client `2.2.1` is the last version to support .NET Framework 3.
 [#213]: https://github.com/DataDog/dogstatsd-csharp-client/issues/213
 [#223]: https://github.com/DataDog/dogstatsd-csharp-client/issues/223
 [#227]: https://github.com/DataDog/dogstatsd-csharp-client/issues/227
+[#231]: https://github.com/DataDog/dogstatsd-csharp-client/issues/231
 [@DanielVukelich]: https://github.com/DanielVukelich
 [@albertofem]: https://github.com/albertofem
 [@alistair]: https://github.com/alistair

--- a/src/StatsdClient/StatsdClient.csproj
+++ b/src/StatsdClient/StatsdClient.csproj
@@ -4,7 +4,7 @@
     <PackageId>DogStatsD-CSharp-Client</PackageId>
     <TargetFrameworks>net461;netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
-    <PackageVersion>9.2.0</PackageVersion>
+    <PackageVersion>9.2.1</PackageVersion>
     <Version>9.0.0</Version>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>StatsdClient.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
## Release 9.2.1

Changelog and version bump for the 9.2.1 NuGet release.

### Included changes
* [BUGFIX] Prevent named pipe write failures from causing unbounded thread growth. The telemetry timer now reschedules itself after each round instead of spawning a new thread every 10s, and backs off after send failures. See #231.

### Checklist
- [x] Changelog entries are accurate
- [x] Version numbers are correct
- [x] PR approved and ready to merge

Once merged, run `/publish-release` to tag, build, and push to NuGet.